### PR TITLE
[FEAT #1] PostgreSQL 스키마용 JPA 엔티티 초기 설정

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,48 @@
+package org.duckdns.petfinderapp.domain.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "chat_message_seq")
+    @SequenceGenerator(
+            name = "chat_message_seq",
+            sequenceName = "chat_message_seq",
+            allocationSize = 1
+    )
+    private Long id;
+
+    @Column(name = "create_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createAt;
+
+    /** 속한 채팅방 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    /** 메시지 전송자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    /** 내용 */
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    /** 읽음 여부 */
+    @Column(nullable = false)
+    private Boolean read;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,46 @@
+package org.duckdns.petfinderapp.domain.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "chat_room_seq")
+    @SequenceGenerator(
+            name = "chat_room_seq",
+            sequenceName = "chat_room_seq",
+            allocationSize = 1
+    )
+    private Long id;
+
+    @Column(name = "create_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createAt;
+
+    /** 연관된 게시글 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostCommon post;
+
+    /** 대화 시작자 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    /** 대화 상대 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
@@ -1,0 +1,43 @@
+package org.duckdns.petfinderapp.domain.map.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.duckdns.petfinderapp.domain.map.enums.SearchType;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SearchHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "search_history_seq")
+    @SequenceGenerator(
+            name = "search_history_seq",
+            sequenceName = "search_history_seq",
+            allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 50, nullable = false)
+    private String keyword;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "search_type", nullable = false)
+    private SearchType searchType;
+
+    @Column(name = "search_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime searchAt;
+}
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/enums/SearchType.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/enums/SearchType.java
@@ -1,0 +1,6 @@
+package org.duckdns.petfinderapp.domain.map.enums;
+
+public enum SearchType {
+    ADDRESS,          // 주소 검색
+    REGISTRATION     // 등록번호 검색
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/notice/entity/Notice.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/notice/entity/Notice.java
@@ -1,0 +1,46 @@
+package org.duckdns.petfinderapp.domain.notice.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "notice_seq")
+    @SequenceGenerator(
+            name = "notice_seq",
+            sequenceName = "notice_seq",
+            allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Column(name = "create_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createAt;
+
+    @Column(name = "image_id", nullable = false)
+    private Integer imageId;
+
+    @Column(name = "target_id", nullable = false)
+    private Integer targetId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "read", nullable = false)
+    private Boolean read;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
@@ -1,0 +1,41 @@
+package org.duckdns.petfinderapp.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.duckdns.petfinderapp.domain.post.enums.NeuterStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@DiscriminatorValue("ADOPT")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Adopt extends PostCommon {
+
+    @Column(name = "animal_num", length = 50)
+    private String animalNum;
+
+    private Integer age;
+    private String color;
+    private String gender;
+
+    @Enumerated(EnumType.STRING)
+    private NeuterStatus neuter;
+
+    private Float weight;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDateTime endDate;
+
+    @Column(name = "shelter_name", length = 50)
+    private String shelterName;
+
+    @Column(name = "shelter_phone", length = 50)
+    private String shelterPhone;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Lost.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Lost.java
@@ -1,0 +1,34 @@
+package org.duckdns.petfinderapp.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.duckdns.petfinderapp.domain.post.enums.NeuterStatus;
+
+@Entity
+@DiscriminatorValue("LOST")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Lost extends PostCommon {
+    private String name;
+    private String gender;
+
+    @Enumerated(EnumType.STRING)
+    private NeuterStatus neuter;
+
+    @Column(name = "animal_num", length = 50)
+    private String animalNum;
+
+    @Column(length = 50)
+    private String bread;
+
+    @Column(length = 50)
+    private String phone;
+
+    private Integer reward;
+}
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -1,0 +1,62 @@
+package org.duckdns.petfinderapp.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.duckdns.petfinderapp.domain.post.enums.PetType;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "dtype", discriminatorType = DiscriminatorType.STRING)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SuperBuilder
+public class PostCommon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "post_common_seq")
+    @SequenceGenerator(
+            name = "post_common_seq",
+            sequenceName = "post_common_seq",
+            allocationSize = 1
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "create_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createAt;
+
+    @Column(insertable = false, updatable = false)
+    private String dtype;
+
+    @Column(nullable = false)
+    private LocalDateTime date;
+
+    @Column(length = 255, nullable = false)
+    private String address;
+
+    @Column(columnDefinition = "POINT", nullable = false)
+    private String coordinates;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pet_type", nullable = false)
+    private PetType petType;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostState state;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostImage.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostImage.java
@@ -1,0 +1,36 @@
+package org.duckdns.petfinderapp.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "post_image_seq")
+    @SequenceGenerator(
+            name = "post_image_seq",
+            sequenceName = "post_image_seq",
+            allocationSize = 1
+    )
+    private Long imageId;    // → post_image.image_id
+
+    /**
+     * 어떤 게시글의 이미지인지
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PostCommon post; // → post_image.post_id
+
+    /**
+     * 이미지 URL
+     */
+    @Column(name = "image_url",
+            nullable = false,
+            columnDefinition = "TEXT")
+    private String imageUrl; // → post_image.image_url
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Sight.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Sight.java
@@ -1,0 +1,14 @@
+package org.duckdns.petfinderapp.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@DiscriminatorValue("SIGHT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class Sight extends PostCommon {
+}
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/NeuterStatus.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/NeuterStatus.java
@@ -1,0 +1,6 @@
+package org.duckdns.petfinderapp.domain.post.enums;
+
+public enum NeuterStatus {
+    NEUTERED,
+    NOT_NEUTERED
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
@@ -1,0 +1,7 @@
+package org.duckdns.petfinderapp.domain.post.enums;
+
+public enum PetType {
+    DOG,
+    CAT,
+    ETC
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PostState.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PostState.java
@@ -1,0 +1,8 @@
+package org.duckdns.petfinderapp.domain.post.enums;
+
+public enum PostState {
+    ADOPT,
+    LOST,
+    SIGHT,
+    NOTICE
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/similarity/entity/Similarity.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/similarity/entity/Similarity.java
@@ -1,0 +1,4 @@
+package org.duckdns.petfinderapp.domain.similarity.entity;
+
+public class Similarity {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -1,0 +1,31 @@
+package org.duckdns.petfinderapp.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.duckdns.petfinderapp.domain.user.enums.UserStatus;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "users")
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq")
+    @SequenceGenerator(name = "user_seq", sequenceName = "user_seq", allocationSize = 1)
+    private Long id;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 10)
+    private String name;
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/enums/UserStatus.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package org.duckdns.petfinderapp.domain.user.enums;
+
+public enum UserStatus {
+    ACTIVATE, DEACTIVATE
+}


### PR DESCRIPTION
## 📌 이슈 번호
#1

## 💬 리뷰 포인트
- User, Notice, SearchHistory 엔티티 작성
- PostCommon 추상 엔티티 + Lost/Adopt/Sight 서브클래스(JOINED 전략) 구현  
- ChatRoom, ChatMessage, PostImage 엔티티 작성  
- PetType, PostState, SearchType, NeuterStatus enum 정의 
- PostgreSQL 예약어 ‘user’ 충돌 회피를 위한 `user` -> `users` 로 변경

## 🚀 상세 설명
본 PR은 PostgreSQL 환경에 맞춰 기본 도메인 모델을 JPA로 매핑하는 작업입니다.  
- `User` 등 기본 엔티티에 `GenerationType.SEQUENCE` 기반 시퀀스 전략을 적용  
- `PostCommon`을 추상 부모로, `Lost`, `Adopt`, `Sight`를 자식으로 하는 JOINED 상속 구조 구현  
- 실시간 채팅용 `ChatRoom`/`ChatMessage`, 이미지 관리용 `PostImage` 엔티티 추가  
- 도메인별 enum(`PetType`, `PostState`, `SearchType`, `NeuterStatus`)을 `EnumType.STRING`으로 매핑  
- PostgreSQL 예약어인 `user` 테이블명 문제를 해결하기 위해 `user` 테이블 명을 `users`로 변경
- `create_at` 등 타임스탬프 필드는 DB 기본값(`CURRENT_TIMESTAMP`)을 사용하도록 `columnDefinition` 지정  
- `coordinates` 필드는 POINT 문자열로 매핑, 추후 PostGIS로 대체 예정

## 📸 스크린샷

## 📢 노트