### PR TITLE
[FEAT] 내 정보 조회 및 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly     'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly     'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package org.duckdns.petfinderapp.domain.user.controller;
+
+import org.duckdns.petfinderapp.domain.user.dto.request.UserUpdateRequest;
+import org.duckdns.petfinderapp.domain.user.dto.response.UserInfoResponse;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.domain.user.service.UserService;
+import org.duckdns.petfinderapp.global.template.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping("/me")
+	public ApiResponse<UserInfoResponse> getCurrentUser(@AuthenticationPrincipal User user) {
+		return ApiResponse.onSuccess(
+			HttpStatus.OK,
+			"내 정보 조회 성공",
+			UserInfoResponse.of(user)
+		);
+	}
+
+	@PutMapping("/me")
+	public ApiResponse<UserInfoResponse> updateUser(
+		@AuthenticationPrincipal User user,
+		@Validated @RequestBody UserUpdateRequest userUpdateRequest
+	) {
+		UserInfoResponse data = userService.updateUserInfo(user, userUpdateRequest);
+		return ApiResponse.onSuccess(
+			HttpStatus.OK,
+			"내 정보 수정 성공",
+			data
+		);
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,15 @@
+package org.duckdns.petfinderapp.domain.user.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record UserUpdateRequest (
+	@Length(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
+	String name,
+	@NotBlank(message = "이미지 URL은 필수입니다.")
+	String imageUrl
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,18 @@
+package org.duckdns.petfinderapp.domain.user.dto.response;
+
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+import lombok.Builder;
+
+@Builder
+public record UserInfoResponse(
+	String name,
+	String image
+) {
+	public static UserInfoResponse of(User user) {
+		return UserInfoResponse.builder()
+			.name(user.getName())
+			.image(user.getImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -22,7 +22,7 @@ public class User {
     @Column(length = 100, nullable = false, unique = true)
     private String providerId;
 
-    @Column(length = 10)
+    @Column(length = 50)
     private String name;
 
     @Column(name = "image_url", columnDefinition = "TEXT")
@@ -31,4 +31,9 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserStatus status;
+
+    public void updateUserInfo(String name, String imageUrl) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package org.duckdns.petfinderapp.domain.user.exception;
+
+import org.duckdns.petfinderapp.global.error.exception.NotFoundGroupException;
+
+public class UserNotFoundException extends NotFoundGroupException {
+
+	protected UserNotFoundException(String message) {
+		super(message);
+	}
+
+	public static UserNotFoundException missingUser() {
+		return new UserNotFoundException("해당 유저 정보가 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.domain.user.service;
+
+import org.duckdns.petfinderapp.domain.user.dto.request.UserUpdateRequest;
+import org.duckdns.petfinderapp.domain.user.dto.response.UserInfoResponse;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+
+public interface UserService {
+	UserInfoResponse updateUserInfo(User user, UserUpdateRequest userUpdateRequest);
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,24 @@
+package org.duckdns.petfinderapp.domain.user.service;
+
+import org.duckdns.petfinderapp.domain.user.dto.request.UserUpdateRequest;
+import org.duckdns.petfinderapp.domain.user.dto.response.UserInfoResponse;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+	private final UserRepository userRepository;
+
+	@Override
+	public UserInfoResponse updateUserInfo(User user, UserUpdateRequest userUpdateRequest) {
+
+		user.updateUserInfo(userUpdateRequest.name(), userUpdateRequest.imageUrl());
+		User savedUser = userRepository.save(user);
+
+		return UserInfoResponse.of(savedUser);
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package org.duckdns.petfinderapp.global.error;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 import org.duckdns.petfinderapp.global.error.exception.BaseException;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -23,6 +28,27 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ex.getStatus())
                 .body(body);
+    }
+
+    // 1) DTO 검증 실패 잡기
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(
+        MethodArgumentNotValidException ex
+    ) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        log.warn("Validation failed: {}", errors);
+
+        ApiResponse<Map<String, String>> body = ApiResponse.onFailure(
+            HttpStatus.BAD_REQUEST,
+            "입력 값이 유효하지 않습니다.",
+            errors    // ApiResponse에 data(payload) 필드를 지원해야 합니다.
+        );
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(body);
     }
 
     // 2) 그 외 모든 예외는 500 Internal Server Error

--- a/src/main/java/org/duckdns/petfinderapp/global/error/exception/NotFoundGroupException.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/exception/NotFoundGroupException.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundGroupException extends BaseException {
+	protected NotFoundGroupException(String message) {
+		super(HttpStatus.NOT_FOUND, message);
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
-		config.setAllowedOrigins(List.of("http://127.0.0.1:5500"));
+		config.setAllowedOriginPatterns(List.of("*"));
 		config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true);

--- a/src/main/java/org/duckdns/petfinderapp/global/template/ApiResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/template/ApiResponse.java
@@ -1,18 +1,27 @@
 package org.duckdns.petfinderapp.global.template;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import org.springframework.http.HttpStatus;
 
 @JsonPropertyOrder({"code", "message", "result"})
 public record ApiResponse<T>(int code, String message, @JsonInclude(JsonInclude.Include.NON_NULL) T result) {
-    // 성공 응답 생성 메서드
-    public static <T> ApiResponse<T> onSuccess(HttpStatus status, String message, T result) {
-        return new ApiResponse<>(status.value(), message, result);
-    }
+	// 성공 응답 생성 메서드
+	public static <T> ApiResponse<T> onSuccess(HttpStatus status, String message, T result) {
+		return new ApiResponse<>(status.value(), message, result);
+	}
 
-    // 실패 응답 생성 메서드
-    public static <T> ApiResponse<T> onFailure(HttpStatus status, String message) {
-        return new ApiResponse<>(status.value(), message, null);
-    }
+	// 실패 응답 생성 메서드
+	public static <T> ApiResponse<T> onFailure(HttpStatus status, String message) {
+		return new ApiResponse<>(status.value(), message, null);
+	}
+
+	// 유효성 검사용 실패 응답 생성 메서드
+	public static ApiResponse<Map<String, String>> onFailure(HttpStatus httpStatus, String s,
+		Map<String, String> errors) {
+		return new ApiResponse<>(httpStatus.value(), s, errors);
+	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
#7

## 💬 리뷰 포인트
- 내 정보 조회(GET `/users/me`) 및 수정(PUT `/users/me`) API 정상 동작 확인  
- `UserUpdateRequest` DTO에 `@NotBlank`, `@Length` 검증 애노테이션 적용  
- 검증 실패 시 `MethodArgumentNotValidException`을 잡아 `ApiResponse` 포맷으로 반환하도록 `GlobalExceptionHandler` 보강  
- `ApiResponse.onFailure(HttpStatus, String, Map<String, String>)` 오버로드 추가  
- `User` 엔티티에 `updateUserInfo()` 메서드 추가 및 `name` 컬럼 길이 확장  
- `UserServiceImpl.updateUserInfo()`에서 엔티티 수정 후 영속화 로직 구현  
- 개발 편의를 위한 `SecurityConfig` CORS 임시 전역 허용 설정

## 🚀 상세 설명
- **Controller**  
  - `UserController#getCurrentUser` (GET `/users/me`): 인증된 사용자 정보 조회  
  - `UserController#updateUser` (PUT `/users/me`): `@Valid @RequestBody UserUpdateRequest`로 입력값 검증 후 정보 수정  

- **DTO & Validation**  
  - `UserUpdateRequest`에 `@NotBlank(message="이름은 필수 입력값입니다.")` 및 `@Length(min=2, max=50, message="이름은 2자 이상 50자 이하로 입력해주세요.")` 추가  

- **Entity & Service**  
  - `User` 엔티티 `name` 컬럼 길이 `50`으로 수정  
  - `User.updateUserInfo(String name, String imageUrl)` 메서드 추가  
  - `UserServiceImpl.updateUserInfo`에서 DTO → 엔티티 반영 후 `save()` 호출  

- **응답·예외 처리**  
  - `ApiResponse`에 검증 오류 맵을 담기 위한 `onFailure(HttpStatus, String, Map<String, String>)` 오버로드 추가  
  - `GlobalExceptionHandler`에 `@ExceptionHandler(MethodArgumentNotValidException.class)` 핸들러 구현, 필드별 에러 메시지를 `result`에 담아 `400 Bad Request` 반환  

- **Security & CORS**  
  - `SecurityConfig`에서 개발 편의를 위해 임시로 모든 Origin 허용 (`allowedOriginPatterns = ["*"]`)  

## 📢 노트