### PR TITLE
[FEAT #9] 유저 탈퇴하기 기능 구현

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/auth/config/KakaoProperties.java
+++ b/src/main/java/org/duckdns/petfinderapp/auth/config/KakaoProperties.java
@@ -13,6 +13,8 @@ import lombok.Setter;
 public class KakaoProperties {
 	private String tokenUrl;
 	private String userInfoUri;
+	private String logoutUrl;
+	private String unlinkUrl;
 	private String clientId;
 	private String clientSecret;
 	private String redirectUri;

--- a/src/main/java/org/duckdns/petfinderapp/auth/controller/AuthController.java
+++ b/src/main/java/org/duckdns/petfinderapp/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import org.duckdns.petfinderapp.auth.service.AuthService;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,12 +15,20 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("")
+@RequestMapping("/auth")
 public class AuthController {
 	private final AuthService authService;
-	@GetMapping("/auth/login/kakao")
+
+	@GetMapping("/login/kakao")
 	public ApiResponse<LoginResponse> kakaoLogin(@RequestParam("code") String code) {
 		LoginResponse data = authService.kakaoLogin(code);
 		return ApiResponse.onSuccess(HttpStatus.OK, "성공", data);
+	}
+
+	@PostMapping("/logout")
+	public ApiResponse<Void> kakaoLogout(@RequestHeader("Authorization") String bearer) {
+		String token = bearer.replace("Bearer ", "");
+		authService.logout(token);
+		return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "로그아웃 성공", null);
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/auth/service/AuthService.java
+++ b/src/main/java/org/duckdns/petfinderapp/auth/service/AuthService.java
@@ -4,4 +4,5 @@ import org.duckdns.petfinderapp.auth.dto.LoginResponse;
 
 public interface AuthService {
 	LoginResponse kakaoLogin(String code);
+	void logout(String accessToken);
 }

--- a/src/main/java/org/duckdns/petfinderapp/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/auth/service/AuthServiceImpl.java
@@ -1,21 +1,23 @@
 package org.duckdns.petfinderapp.auth.service;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.duckdns.petfinderapp.auth.config.KakaoProperties;
 import org.duckdns.petfinderapp.auth.dto.KakaoTokenResponse;
 import org.duckdns.petfinderapp.auth.dto.KakaoUserInfoResponse;
 import org.duckdns.petfinderapp.auth.dto.LoginResponse;
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.domain.user.exception.UserNotFoundException;
 import org.duckdns.petfinderapp.domain.user.repository.UserRepository;
 import org.duckdns.petfinderapp.global.security.JwtTokenProvider;
+import org.duckdns.petfinderapp.global.security.TokenBlackListService;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -29,8 +31,10 @@ public class AuthServiceImpl implements AuthService {
 	private final KakaoProperties kakaoProperties;
 	private final RestTemplate restTemplate;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final TokenBlackListService tokenBlackListService;
 
 	@Override
+	@Transactional
 	public LoginResponse kakaoLogin(String code) {
 		KakaoTokenResponse tokenResponse = requestAccessToken(code);
 		KakaoUserInfoResponse userInfo = fetchUserInfo(tokenResponse.accessToken());
@@ -39,6 +43,14 @@ public class AuthServiceImpl implements AuthService {
 		String accessToken = jwtTokenProvider.createAccessToken(user.getProviderId(), List.of());
 
 		return LoginResponse.of(accessToken);
+	}
+
+	@Override
+	public void logout(String accessToken) {
+		tokenBlackListService.addToBlackList(
+			jwtTokenProvider.getJti(accessToken),
+			jwtTokenProvider.getExpiration(accessToken)
+		);
 	}
 
 	private KakaoTokenResponse requestAccessToken(String code) {
@@ -72,12 +84,14 @@ public class AuthServiceImpl implements AuthService {
 		return response.getBody();
 	}
 
-	private User registerNewUserIfNeeded(KakaoUserInfoResponse userInfo) {
-		Optional<User> existing = userRepository.findByProviderId(userInfo.getId());
-		if (existing.isEmpty()) {
-			User user = userInfo.toUser();
-			return userRepository.save(user);
+	private User registerNewUserIfNeeded(KakaoUserInfoResponse info) {
+		int updated = userRepository.activateByProviderId(info.getId());
+		if (updated > 0) {
+			// 방금 activate 한 유저 다시 조회 (이때는 @Where 가 걸리지만 이미 ACTIVATE 됐으니 OK)
+			return userRepository.findByProviderId(info.getId())
+				.orElseThrow(UserNotFoundException::missingUser);
 		}
-		return existing.get();
+		// 신규 가입
+		return userRepository.save(info.toUser());
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import org.duckdns.petfinderapp.global.template.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,5 +43,11 @@ public class UserController {
 			"내 정보 수정 성공",
 			data
 		);
+	}
+
+	@DeleteMapping("/me")
+	public ApiResponse<Void> deleteUser(@AuthenticationPrincipal User user) {
+		userService.deleteUser(user);
+		return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴 성공", null);
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
@@ -46,7 +46,9 @@ public class UserController {
 	}
 
 	@DeleteMapping("/me")
-	public ApiResponse<Void> deleteUser(@AuthenticationPrincipal User user) {
+	public ApiResponse<Void> deleteUser(
+		@AuthenticationPrincipal User user
+	) {
 		userService.deleteUser(user);
 		return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴 성공", null);
 	}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -3,6 +3,8 @@ package org.duckdns.petfinderapp.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.duckdns.petfinderapp.domain.user.enums.UserStatus;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -10,6 +12,8 @@ import org.duckdns.petfinderapp.domain.user.enums.UserStatus;
 @AllArgsConstructor
 @Table(name = "users")
 @Builder
+@SQLDelete(sql = "UPDATE users SET status = 'DEACTIVATE' WHERE id = ?")
+@SQLRestriction("status <> 'DEACTIVATE'")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq")
@@ -19,7 +23,7 @@ public class User {
     @Column(length = 50, nullable = false)
     private String provider;
 
-    @Column(length = 100, nullable = false, unique = true)
+    @Column(name = "provider_id", length = 100, nullable = false, unique = true)
     private String providerId;
 
     @Column(length = 50)
@@ -28,8 +32,8 @@ public class User {
     @Column(name = "image_url", columnDefinition = "TEXT")
     private String imageUrl;
 
-    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private UserStatus status;
 
     public void updateUserInfo(String name, String imageUrl) {
@@ -37,7 +41,8 @@ public class User {
         this.imageUrl = imageUrl;
     }
 
-    public void deactivate() {
-        this.status = UserStatus.DEACTIVATE;
+    public void activate() {
+        this.status = UserStatus.ACTIVATE;
     }
+
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -36,4 +36,8 @@ public class User {
         this.name = name;
         this.imageUrl = imageUrl;
     }
+
+    public void deactivate() {
+        this.status = UserStatus.DEACTIVATE;
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/repository/UserRepository.java
@@ -4,9 +4,18 @@ import java.util.Optional;
 
 import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByProviderId(String providerId);
+
+	@Modifying
+	@Query(
+		value = "UPDATE users SET status = 'ACTIVATE' WHERE provider_id = :pid",
+		nativeQuery = true
+	)
+	int activateByProviderId(String pid);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserService.java
@@ -6,4 +6,6 @@ import org.duckdns.petfinderapp.domain.user.entity.User;
 
 public interface UserService {
 	UserInfoResponse updateUserInfo(User user, UserUpdateRequest userUpdateRequest);
+
+	void deleteUser(User user);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
@@ -21,4 +21,10 @@ public class UserServiceImpl implements UserService {
 
 		return UserInfoResponse.of(savedUser);
 	}
+
+	@Override
+	public void deleteUser(User user) {
+		user.deactivate();
+		userRepository.save(user);
+	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/service/UserServiceImpl.java
@@ -24,7 +24,6 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public void deleteUser(User user) {
-		user.deactivate();
-		userRepository.save(user);
+		userRepository.delete(user);
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/global/security/CacheConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/CacheConfig.java
@@ -1,0 +1,16 @@
+package org.duckdns.petfinderapp.global.security;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+	@Bean
+	public CacheManager cacheManager() {
+		return new ConcurrentMapCacheManager("blackList");
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package org.duckdns.petfinderapp.global.security;
 import java.io.IOException;
 
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.domain.user.exception.UserNotFoundException;
 import org.duckdns.petfinderapp.domain.user.repository.UserRepository;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserRepository userRepository;
+	private final TokenBlackListService blacklistService;
 
 	@Override
 	protected void doFilterInternal(
@@ -32,12 +34,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			String token = header.substring(7);
 
 			if (jwtTokenProvider.validateToken(token)) {
-				// 1) 토큰에서 사용자 ID 획득
+				// 1) 블랙리스트 체크
+				if(blacklistService.isBlackListed(jwtTokenProvider.getJti(token))) {
+					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is blacklisted");
+					return;
+				}
+
+				// 2) 토큰에서 사용자 ID 획득
 				String userId = jwtTokenProvider.getUserId(token);
 
-				// 2) UserDetailsService 로부터 실제 사용자 정보 조회
+				// 3) UserDetailsService 로부터 실제 사용자 정보 조회
 				User user = userRepository.findByProviderId(userId)
-					.orElseThrow();
+					.orElseThrow(UserNotFoundException::missingUser);
 
 				// 4) principal 에 엔티티를, credentials 는 null, 권한 목록 세팅
 				UsernamePasswordAuthenticationToken auth =

--- a/src/main/java/org/duckdns/petfinderapp/global/security/JwtTokenProvider.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/JwtTokenProvider.java
@@ -4,9 +4,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.crypto.SecretKey;
 
@@ -32,12 +34,14 @@ public class JwtTokenProvider {
 
 	// 1) 토큰 생성
 	public String createToken(String userId, List<String> roles) {
-		Map<String,Object> claims = Map.of("roles", roles);
+		Map<String, Object> claims = Map.of("roles", roles);
 
 		Date now = new Date();
 		Date exp = new Date(now.getTime() + validityInMilliseconds);
+		String jti = UUID.randomUUID().toString();
 
 		return Jwts.builder()
+			.id(jti)
 			.claims(claims)
 			.subject(userId)
 			.issuedAt(now)
@@ -46,8 +50,32 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
-	public String createAccessToken(String  userId, List<String> roles) {
+	public String createAccessToken(String userId, List<String> roles) {
 		return createToken(userId, roles);
+	}
+
+	public Duration getExpiration(String token) {
+		Claims body = Jwts.parser()
+			.verifyWith(getSigningKey())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+
+		Date expiration = body.getExpiration();
+		if (expiration == null) {
+			return Duration.ZERO; // No expiration set
+		}
+		return Duration.between(new Date().toInstant(), expiration.toInstant());
+	}
+
+	public String getJti(String token) {
+		Claims body = Jwts.parser()
+			.verifyWith(getSigningKey())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+
+		return body.getId();
 	}
 
 	// 2) 토큰에서 사용자 ID 추출

--- a/src/main/java/org/duckdns/petfinderapp/global/security/RestAccessDeniedHandler.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/RestAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package org.duckdns.petfinderapp.global.security;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근이 거부되었습니다.");
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package org.duckdns.petfinderapp.global.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
@@ -21,9 +21,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 	private final JwtTokenProvider jwtTokenProvider;
+	private final RestAuthenticationEntryPoint entryPoint;
+	private final RestAccessDeniedHandler accessDeniedHandler;
+	private final UserRepository userRepository;
+	private final TokenBlackListService blackListService;
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http, UserRepository userRepository) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.cors(Customizer.withDefaults())
 			// CSRF 완전 비활성화
@@ -31,6 +35,10 @@ public class SecurityConfig {
 			// stateless 세션 정책
 			.sessionManagement(sm -> sm
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+			.exceptionHandling(ex -> ex
+				.authenticationEntryPoint(entryPoint)
+				.accessDeniedHandler(accessDeniedHandler)
 			)
 			// 권한 검사 설정
 			.authorizeHttpRequests(auth -> auth
@@ -43,7 +51,7 @@ public class SecurityConfig {
 
 			// JWT 필터 적용
 		http.addFilterBefore(
-			new JwtAuthenticationFilter(jwtTokenProvider, userRepository),
+			new JwtAuthenticationFilter(jwtTokenProvider, userRepository, blackListService),
 			UsernamePasswordAuthenticationFilter.class
 		);
 

--- a/src/main/java/org/duckdns/petfinderapp/global/security/TokenBlackListService.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/TokenBlackListService.java
@@ -1,0 +1,33 @@
+package org.duckdns.petfinderapp.global.security;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenBlackListService {
+	private final Cache blacklist;
+
+	public TokenBlackListService(CacheManager cacheManager) {
+		this.blacklist = cacheManager.getCache("blackList");
+	}
+
+	public void addToBlackList(String jti, Duration ttl) {
+		blacklist.put(jti, Instant.now().plus(ttl));
+	}
+
+	public boolean isBlackListed(String jti) {
+		Instant expiresAt = blacklist.get(jti, Instant.class);
+		if (expiresAt == null) {
+			return false;
+		}
+		if (Instant.now().isAfter(expiresAt)) {
+			blacklist.evict(jti); // Remove expired token
+			return false;
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
# ✨ 로그아웃 및 회원 탈퇴 기능 추가

## 📌 이슈 번호  
#9  

## 💬 리뷰 포인트  
- `POST /auth/logout` — JWT 블랙리스트 등록 후 로그아웃  
- `DELETE /users/me` — 소프트-삭제 방식의 회원 탈퇴  

## 🚀 상세 내역  

### 1. AuthController  
- `@PostMapping("/auth/logout")` 엔드포인트 추가  
  - `Authorization: Bearer {token}` 헤더에서 토큰 파싱  
  - `authService.logout(token)` 호출  
  - `204 NO_CONTENT`, `"로그아웃 성공"` 반환  

### 2. AuthService & AuthServiceImpl  
- `AuthService` 인터페이스에 `void logout(String accessToken)` 선언  
- `AuthServiceImpl.logout` 구현  
  1. `jwtTokenProvider.getJti(token)` → JTI 추출  
  2. `jwtTokenProvider.getExpiration(token)` → 남은 TTL 계산  
  3. `tokenBlackListService.addToBlackList(jti, ttl)` 호출  

### 3. TokenBlackListService  
- `addToBlackList(String jti, Duration ttl)`  
  - 캐시 `"blackList"`에 `(jti → 만료시각)` 저장  
- `isBlackListed(String jti)`  
  - 만료되지 않은 토큰만 `true` 반환, 만료 시 자동 제거  

### 4. JwtAuthenticationFilter  
- 생성자에 `TokenBlackListService` 주입  
- 토큰 검증 후 블랙리스트 체크  

## 노트