### PR TITLE
[FEAT #14] 채팅 메시지 조회 

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatMessageController.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class ChatController {
+public class ChatMessageController {
 	private final ChatService chatService;
 
 	@Transactional

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatRoomController.java
@@ -1,0 +1,34 @@
+package org.duckdns.petfinderapp.domain.chat.controller;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.duckdns.petfinderapp.domain.chat.dto.ChatMessageDto;
+import org.duckdns.petfinderapp.domain.chat.service.ChatMessageService;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.global.template.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chatrooms")
+public class ChatRoomController {
+
+    private final ChatMessageService chatMessageService;
+
+    @GetMapping("/{roomId}/messages")
+    public ApiResponse<Page<ChatMessageDto>> getChatRoomMessages(
+            @AuthenticationPrincipal @NotNull User user,
+            @PathVariable @NotNull Long roomId,
+            Pageable pageable) {
+
+        Page<ChatMessageDto> data = chatMessageService.getChatRoomMessages(user, roomId, pageable);
+        return ApiResponse.onSuccess(HttpStatus.OK, "채팅 메시지 조회 성공", data);
+    }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
@@ -15,7 +15,7 @@ public record ChatMessageDto(
 	Long senderId,
 	@NotBlank
 	String message,
-	LocalDateTime createdAt,
+	LocalDateTime createAt,
 	PostInfoDto post,
 	Boolean isRead
 ) {
@@ -23,7 +23,7 @@ public record ChatMessageDto(
 		return ChatMessageDto.builder()
 			.senderId(chatMessage.getSender().getId())
 			.message(chatMessage.getContent())
-			.createdAt(chatMessage.getCreateAt())
+			.createAt(chatMessage.getCreateAt())
 			.post(postInfoDto)
 			.isRead(chatMessage.getRead())
 			.build();

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
@@ -1,16 +1,31 @@
 package org.duckdns.petfinderapp.domain.chat.dto;
 
+import lombok.Builder;
+import org.duckdns.petfinderapp.domain.chat.entity.ChatMessage;
 import org.duckdns.petfinderapp.domain.post.dto.PostInfoDto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDateTime;
+
+@Builder
 public record ChatMessageDto(
 	@NotNull
 	Long senderId,
 	@NotBlank
 	String message,
-
-	PostInfoDto post
+	LocalDateTime createdAt,
+	PostInfoDto post,
+	Boolean isRead
 ) {
+	public static ChatMessageDto of(ChatMessage chatMessage, PostInfoDto postInfoDto) {
+		return ChatMessageDto.builder()
+			.senderId(chatMessage.getSender().getId())
+			.message(chatMessage.getContent())
+			.createdAt(chatMessage.getCreateAt())
+			.post(postInfoDto)
+			.isRead(chatMessage.getRead())
+			.build();
+	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
@@ -6,6 +6,8 @@ import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -43,4 +45,12 @@ public class ChatRoom {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomAccessDeniedException.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomAccessDeniedException.java
@@ -1,0 +1,13 @@
+package org.duckdns.petfinderapp.domain.chat.exception;
+
+import org.duckdns.petfinderapp.global.error.exception.AccessDeniedGroupException;
+
+public class ChatRoomAccessDeniedException extends AccessDeniedGroupException {
+    protected ChatRoomAccessDeniedException(String message) {
+        super(message);
+    }
+
+    public static ChatRoomAccessDeniedException accessDenied() {
+        return new ChatRoomAccessDeniedException("해당 채팅방에 접근할 수 없습니다.");
+    }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,13 @@
+package org.duckdns.petfinderapp.domain.chat.exception;
+
+import org.duckdns.petfinderapp.global.error.exception.NotFoundGroupException;
+
+public class ChatRoomNotFoundException extends NotFoundGroupException {
+    protected ChatRoomNotFoundException(String message) {
+        super(message);
+    }
+
+    public static ChatRoomNotFoundException missingChatRoom() {
+        return new ChatRoomNotFoundException("해당 채팅방이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,10 @@
 package org.duckdns.petfinderapp.domain.chat.repository;
 
 import org.duckdns.petfinderapp.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    Page<ChatMessage> findAllByChatRoomId(Long roomId, Pageable pageable);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,10 @@
+package org.duckdns.petfinderapp.domain.chat.service;
+
+import org.duckdns.petfinderapp.domain.chat.dto.ChatMessageDto;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ChatMessageService {
+    Page<ChatMessageDto> getChatRoomMessages(User user, Long roomId, Pageable pageable);
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageServiceImpl.java
@@ -1,0 +1,37 @@
+package org.duckdns.petfinderapp.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.duckdns.petfinderapp.domain.chat.dto.ChatMessageDto;
+import org.duckdns.petfinderapp.domain.chat.entity.ChatMessage;
+import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
+import org.duckdns.petfinderapp.domain.chat.exception.ChatRoomAccessDeniedException;
+import org.duckdns.petfinderapp.domain.chat.exception.ChatRoomNotFoundException;
+import org.duckdns.petfinderapp.domain.chat.repository.ChatMessageRepository;
+import org.duckdns.petfinderapp.domain.chat.repository.ChatRoomRepository;
+import org.duckdns.petfinderapp.domain.post.dto.PostInfoDto;
+import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageServiceImpl implements ChatMessageService {
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public Page<ChatMessageDto> getChatRoomMessages(User user, Long roomId, Pageable pageable) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(ChatRoomNotFoundException::missingChatRoom);
+
+        if (!chatRoom.getSender().equals(user) && !chatRoom.getReceiver().equals(user)) {
+            throw ChatRoomAccessDeniedException.accessDenied();
+        }
+
+        PostInfoDto postInfoDto = PostInfoDto.of(chatRoom.getPost());
+        Page<ChatMessage> chatMessagesPage = chatMessageRepository.findAllByChatRoomId(roomId, pageable);
+
+        return chatMessagesPage.map(message -> ChatMessageDto.of(message, postInfoDto));
+    }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/PostInfoDto.java
@@ -1,14 +1,29 @@
 package org.duckdns.petfinderapp.domain.post.dto;
 
+import lombok.Builder;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record PostInfoDto (
 	Long postId,
-	String state,
+	PostState state,
 	LocalDateTime date,
 	String address,
 	String description,
 	String imageUrl
 ) {
 
+    public static PostInfoDto of(PostCommon post) {
+		return PostInfoDto.builder()
+			.postId(post.getId())
+			.state(post.getState())
+			.date(post.getCreateAt())
+			.address(post.getAddress())
+			.description(post.getDescription())
+			.imageUrl(post.getImages().get(0).getImageUrl())
+			.build();
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -8,6 +8,8 @@ import org.duckdns.petfinderapp.domain.post.enums.PostState;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -59,4 +61,8 @@ public class PostCommon {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PostState state;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostImage> images = new ArrayList<>();
 }

--- a/src/main/java/org/duckdns/petfinderapp/global/error/exception/AccessDeniedGroupException.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/exception/AccessDeniedGroupException.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AccessDeniedGroupException extends BaseException{
+    protected AccessDeniedGroupException(String message) {
+        super(HttpStatus.FORBIDDEN, message);
+    }
+}

--- a/src/main/java/org/duckdns/petfinderapp/global/template/ApiResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/template/ApiResponse.java
@@ -7,11 +7,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import org.springframework.http.HttpStatus;
 
-@JsonPropertyOrder({"code", "message", "result"})
-public record ApiResponse<T>(int code, String message, @JsonInclude(JsonInclude.Include.NON_NULL) T result) {
+@JsonPropertyOrder({"status", "message", "data"})
+public record ApiResponse<T>(int status, String message, @JsonInclude(JsonInclude.Include.NON_NULL) T data) {
 	// 성공 응답 생성 메서드
-	public static <T> ApiResponse<T> onSuccess(HttpStatus status, String message, T result) {
-		return new ApiResponse<>(status.value(), message, result);
+	public static <T> ApiResponse<T> onSuccess(HttpStatus status, String message, T data) {
+		return new ApiResponse<>(status.value(), message, data);
 	}
 
 	// 실패 응답 생성 메서드


### PR DESCRIPTION
## 📌 이슈 번호

\#14

## 💬 리뷰 포인트

* 채팅 메시지 조회 API 추가 (`/chatrooms/{roomId}/messages`)
* `ChatMessageDto` 및 `PostInfoDto` 필드 확장
* `ChatRoom`·`PostCommon` 엔티티 연관관계 매핑 보완
* `ChatMessageService` 인터페이스 정의 및 구현체에 예외 처리 로직 추가
* `ChatRoomNotFoundException`·`ChatRoomAccessDeniedException`·`AccessDeniedGroupException` 추가
* `ApiResponse` 필드명(`code`→`status`, `result`→`data`) 및 메서드 수정

## 🚀 상세 설명

1. Controller

   * `ChatRoomController` 생성

     * GET `/chatrooms/{roomId}/messages` 엔드포인트로 인증된 사용자의 채팅 메시지 페이징 조회

2. DTO

   * `ChatMessageDto`

     * 기존: `senderId`, `message`, `createAt`
     * 신규:

       * `post`: `PostInfoDto` (관련 게시글 정보; 게시글이 없으면 `null`)
       * `isRead`: `Boolean` (읽음 여부)
   * `PostInfoDto`

     * `state` 타입을 `String`→`PostState` enum으로 변경
     * `postId`, `state`, `date`, `address`, `description`, `imageUrl` 빌더 패턴 유지

3. Entity

   * `ChatRoom`

     * 메시지 목록 매핑(`@OneToMany(mappedBy="chatRoom") List<ChatMessage> messages`) 추가
   * `PostCommon`

     * 게시글 이미지 목록(`List<PostImage> images`) 기본값(`@Builder.Default`) 설정 추가

4. Repository

   * `ChatMessageRepository`

     * `findAllByChatRoomId(Long roomId, Pageable pageable)` 메서드 선언

5. Service

   * `ChatMessageService` 인터페이스 정의
   * `ChatMessageServiceImpl` 구현체

     * 채팅방 존재 여부 확인 → `ChatRoomNotFoundException` 발생
     * 접근 권한 검사 → `ChatRoomAccessDeniedException` 발생
     * 메시지 조회 후 `ChatMessageDto.of(...)` 으로 변환

6. Exception

   * `ChatRoomNotFoundException`, `ChatRoomAccessDeniedException` 추가
   * 공통 예외 `AccessDeniedGroupException` 정의

7. Global Template

   * `ApiResponse`

     * JSON 필드명 변경: `code`→`status`, `result`→`data` (`@JsonPropertyOrder` 업데이트)
     * `onSuccess`/`onFailure` 메서드 시그니처 및 내부 파라미터명 수정

## 📸 스크린샷


## 📢 노트