### PR TITLE
[REFACTOR #18] 엔티티 생성 전략 변경 및 DB 예약어 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/ChatMessageDto.java
@@ -25,7 +25,7 @@ public record ChatMessageDto(
 			.message(chatMessage.getContent())
 			.createAt(chatMessage.getCreateAt())
 			.post(postInfoDto)
-			.isRead(chatMessage.getRead())
+			.isRead(chatMessage.getIsRead())
 			.build();
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
@@ -15,11 +15,6 @@ public class ChatMessage {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @SequenceGenerator(
-            name = "chat_message_seq",
-            sequenceName = "chat_message_seq",
-            allocationSize = 1
-    )
     private Long id;
 
     @Column(name = "create_at",

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class ChatMessage {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "chat_message_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @SequenceGenerator(
             name = "chat_message_seq",
             sequenceName = "chat_message_seq",

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatMessage.java
@@ -44,7 +44,7 @@ public class ChatMessage {
 
     /** 읽음 여부 */
     @Column(nullable = false)
-    private Boolean read;
+    private Boolean isRead;
 
 	public static ChatMessage of(ChatRoom chatRoom, User sender, String message) {
         return ChatMessage.builder()
@@ -52,7 +52,7 @@ public class ChatMessage {
             .chatRoom(chatRoom)
             .sender(sender)
             .content(message)
-            .read(false) // 기본값은 읽지 않은 상태로 설정
+            .isRead(false) // 기본값은 읽지 않은 상태로 설정
             .build();
 	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
@@ -18,11 +18,6 @@ public class ChatRoom {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @SequenceGenerator(
-            name = "chat_room_seq",
-            sequenceName = "chat_room_seq",
-            allocationSize = 1
-    )
     private Long id;
 
     @Column(name = "create_at",

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class ChatRoom {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "chat_room_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @SequenceGenerator(
             name = "chat_room_seq",
             sequenceName = "chat_room_seq",

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
@@ -16,11 +16,6 @@ public class SearchHistory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @SequenceGenerator(
-            name = "search_history_seq",
-            sequenceName = "search_history_seq",
-            allocationSize = 1
-    )
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/entity/SearchHistory.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public class SearchHistory {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "search_history_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @SequenceGenerator(
             name = "search_history_seq",
             sequenceName = "search_history_seq",

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class PostCommon {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "post_common_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @SequenceGenerator(
             name = "post_common_seq",
             sequenceName = "post_common_seq",

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -22,11 +22,6 @@ public class PostCommon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @SequenceGenerator(
-            name = "post_common_seq",
-            sequenceName = "post_common_seq",
-            allocationSize = 1
-    )
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -17,7 +17,6 @@ import org.hibernate.annotations.SQLRestriction;
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @SequenceGenerator(name = "user_seq", sequenceName = "user_seq", allocationSize = 1)
     private Long id;
 
     @Column(length = 50, nullable = false)

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/entity/User.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLRestriction("status <> 'DEACTIVATE'")
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @SequenceGenerator(name = "user_seq", sequenceName = "user_seq", allocationSize = 1)
     private Long id;
 


### PR DESCRIPTION
## 📌 이슈 번호
\#18 

## 💬 리뷰 포인트
- 엔티티별 기본 키 생성 전략을 `SEQUENCE`에서 `IDENTITY`로 변경  
- `ChatMessage`의 읽음 여부 필드명 `read` → `isRead`로 수정 및 DTO 빌더 반영  
- `build.gradle`에 MySQL 커넥터 및 JUnit 런처 의존성 정리  

## 🚀 상세 설명
1. **`build.gradle` 의존성 추가/정리**  
   - `com.mysql:mysql-connector-j` 런타임 의존성 추가  
   - `org.junit.platform:junit-platform-launcher` 테스트 런타임 의존성 유지  

2. **엔티티 기본 키 생성 전략 변경**  
   - `ChatMessage`, `ChatRoom`, `SearchHistory`, `PostCommon`, `User` 등 도메인 엔티티의 `@GeneratedValue` 전략을 `SEQUENCE` → `IDENTITY`로 통일  

3. **읽음 여부 필드명 및 DTO 반영**  
   - `ChatMessage` 엔티티의 `private Boolean read` → `private Boolean isRead`로 변경  
   - 이에 따른 `ChatMessageDto.of(...)` 내부 `.isRead(...)` 호출로 수정  

## 📸 스크린샷

## 📢 노트