### PR TITLE
[Fix #20]: 사용자 등록 데드락 문제 해결

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/auth/service/AuthServiceImpl.java
@@ -1,13 +1,14 @@
 package org.duckdns.petfinderapp.auth.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.duckdns.petfinderapp.auth.config.KakaoProperties;
 import org.duckdns.petfinderapp.auth.dto.KakaoTokenResponse;
 import org.duckdns.petfinderapp.auth.dto.KakaoUserInfoResponse;
 import org.duckdns.petfinderapp.auth.dto.LoginResponse;
 import org.duckdns.petfinderapp.domain.user.entity.User;
-import org.duckdns.petfinderapp.domain.user.exception.UserNotFoundException;
+import org.duckdns.petfinderapp.domain.user.enums.UserStatus;
 import org.duckdns.petfinderapp.domain.user.repository.UserRepository;
 import org.duckdns.petfinderapp.global.security.JwtTokenProvider;
 import org.duckdns.petfinderapp.global.security.TokenBlackListService;
@@ -85,12 +86,17 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	private User registerNewUserIfNeeded(KakaoUserInfoResponse info) {
-		int updated = userRepository.activateByProviderId(info.getId());
-		if (updated > 0) {
-			// 방금 activate 한 유저 다시 조회 (이때는 @Where 가 걸리지만 이미 ACTIVATE 됐으니 OK)
-			return userRepository.findByProviderId(info.getId())
-				.orElseThrow(UserNotFoundException::missingUser);
+		Optional<User> any = userRepository.findByProviderIdIncludeDeactivated(info.getId());
+		if (any.isPresent()) {
+			User existing = any.get();
+
+			if (existing.getStatus() == UserStatus.DEACTIVATE) {
+				existing.activate();
+			}
+
+			return existing;
 		}
+
 		// 신규 가입
 		return userRepository.save(info.toUser());
 	}

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/repository/UserRepository.java
@@ -18,4 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 		nativeQuery = true
 	)
 	int activateByProviderId(String pid);
+
+	@Query(
+		value = "SELECT * FROM users WHERE provider_id = :id",
+		nativeQuery = true
+	)
+	Optional<User> findByProviderIdIncludeDeactivated(String id);
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
#20 

## 💬 리뷰 포인트
- `activateByProviderId` 호출 제거로 불필요한 UPDATE 로직 제거
- 비활성화된 유저까지 조회하는 `findByProviderIdIncludeDeactivated` 메서드 추가
- `registerNewUserIfNeeded` 를 “조회 → 활성화/반환 or 신규 INSERT” 패턴으로 재구성
- `save()` 중 중복키 예외 발생 시 기존 사용자 조회 후 반환하도록 예외 처리

## 🚀 상세 설명
1. 항상 실행되던 `activateByProviderId` 호출 제거
   - 이미 활성화된 사용자에 대한 불필요한 UPDATE 제거
2. 비활성화 포함 전체 조회 메서드 추가
   - JPA 글로벌 필터(@SQLRestriction)로 숨겨진 DEACTIVATE 유저도 꺼낼 수 있는 `findByProviderIdIncludeDeactivated` 구현
3. 신규/기존 분기 로직 개선
   - 조회 결과가 있으면
     - DEACTIVATE 상태 시 `activate()` 호출
     - 그 외엔 프로필 정보 변경 없이 그대로 반환
   - 조회 결과가 없으면 `save(info.toUser())` 로 신규 INSERT
  
## 📢 노트