### PR TITLE
Refactor[#25]: 게시글 사용자 정보 처리 방식 개선

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/request/CommonCreate.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/request/CommonCreate.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class CommonCreate {
-    private Long userId;
     private PostState state;
     private LocalDateTime date;
     private String address;
@@ -26,7 +25,6 @@ public class CommonCreate {
         Coordinates coordEntity = coordinates.toEntity();
 
         return PostCommon.builder()
-                .id(userId)
                 .state(state)
                 .date(date)
                 .address(address)

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/controller/FcmController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/controller/FcmController.java
@@ -3,7 +3,9 @@ package org.duckdns.petfinderapp.domain.push.controller;
 import lombok.RequiredArgsConstructor;
 import org.duckdns.petfinderapp.domain.push.dto.FcmResponseDto;
 import org.duckdns.petfinderapp.domain.push.service.FcmService;
+import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,14 +16,16 @@ public class FcmController {
     private final FcmService fcmService;
 
     @PostMapping("notice/token")
-    public ResponseEntity<Void> saveToken(@RequestBody FcmResponseDto dto){
-        fcmService.saveToken(dto.getUserId(), dto.getToken());
+    public ResponseEntity<Void> saveToken(@RequestBody FcmResponseDto dto,
+                                          @AuthenticationPrincipal User user){
+        fcmService.saveToken(user, dto.getToken());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("notice/send")
-    public ResponseEntity<Void> send(@RequestBody FcmResponseDto dto){
-        fcmService.sendMessage(dto.getUserId(), dto.getTitle(), dto.getMessage());
+    public ResponseEntity<Void> send(@RequestBody FcmResponseDto dto,
+                                     @AuthenticationPrincipal User user){
+        fcmService.sendMessage(user, dto.getTitle(), dto.getMessage());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/dto/FcmResponseDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/dto/FcmResponseDto.java
@@ -4,7 +4,6 @@ import lombok.Data;
 
 @Data
 public class FcmResponseDto {
-    private Long userId;
     private String token;
     private String title;
     private String message;

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/entity/FcmToken.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/entity/FcmToken.java
@@ -1,12 +1,10 @@
 package org.duckdns.petfinderapp.domain.push.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.duckdns.petfinderapp.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
@@ -19,13 +17,14 @@ public class FcmToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    private boolean read;
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
     private String token;
     private LocalDateTime updatedAt;
 
-    public FcmToken(Long userId, String token) {
-        this.userId = userId;
+    public FcmToken(User user, String token) {
+        this.user = user;
         this.token = token;
         this.updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/repository/FcmTokenRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/repository/FcmTokenRepository.java
@@ -1,10 +1,11 @@
 package org.duckdns.petfinderapp.domain.push.repository;
 
 import org.duckdns.petfinderapp.domain.push.entity.FcmToken;
+import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken, String> {
-    Optional<FcmToken> findByUserId(Long userId);
+    Optional<FcmToken> findByUserId(User user);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/service/FcmService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/service/FcmService.java
@@ -7,28 +7,31 @@ import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import org.duckdns.petfinderapp.domain.push.entity.FcmToken;
 import org.duckdns.petfinderapp.domain.push.repository.FcmTokenRepository;
+import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class FcmService {
     private final FcmTokenRepository fcmTokenRepository;
 
-    public void saveToken(Long userId, String token) {
-        FcmToken tokenEntity = fcmTokenRepository.findByUserId(userId)
+    @Transactional
+    public void saveToken(User user, String token) {
+        FcmToken tokenEntity = fcmTokenRepository.findByUserId(user)
                 .map(t -> {
                     t.updateToken(token);
                     return t;
                 })
-                .orElse(new FcmToken(userId, token));
+                .orElse(new FcmToken(user, token));
 
         fcmTokenRepository.save(tokenEntity);
     }
 
-    public void sendMessage(Long userId, String title, String message) {
-        String token = fcmTokenRepository.findByUserId(userId)
+    public void sendMessage(User user, String title, String message) {
+        String token = fcmTokenRepository.findByUserId(user)
                 .map(FcmToken::getToken)
-                .orElseThrow(() -> new IllegalArgumentException("토큰 없음"));
+                .orElseThrow(() -> new IllegalArgumentException("사용자 토큰을 찾을 수 없습니다."));
 
         Notification notification = Notification.builder()
                 .setTitle(title)


### PR DESCRIPTION
## 📌 이슈 번호
> #25 

## 💬 리뷰 포인트
- Post
> Dto → Entity의 형태에서는 User이 잘 들어가 있음을 확인. 요청으로 받는 Dto에서 UserId를 삭제함.
- Push
> 기존의 처리 방식에서는 userId를 JSON으로 넣었어야 했음. 현재, User에서 userId를 가져오도록 변경
