### PR TITLE
[FIX #27]: CreateAt가 null로 전달되는 현상

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -6,6 +6,7 @@ import lombok.experimental.SuperBuilder;
 import org.duckdns.petfinderapp.domain.post.enums.PetType;
 import org.duckdns.petfinderapp.domain.post.enums.PostState;
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ public class PostCommon {
             nullable = false,
             updatable = false,
             columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @CreationTimestamp
     private LocalDateTime createAt;
 
     @Column(insertable = false, updatable = false)

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -31,8 +31,7 @@ public class PostCommon {
 
     @Column(name = "create_at",
             nullable = false,
-            updatable = false,
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+            updatable = false)
     @CreationTimestamp
     private LocalDateTime createAt;
 


### PR DESCRIPTION
## 📌 이슈 번호
\#27

## 💬 리뷰 포인트
- createAt 필드에 생성 일시 자동 입력 기능 추가
- columnDefinition 삭제

## 🚀 상세 설명
- columnDefinition 삭제
   - Hibernate가 INSERT 에 createAt 컬럼을 포함
   - Java 객체의 필드가 아직 세팅되지 않았으니 바인딩 값은 NULL
   - DB DEFAULT (CURRENT_TIMESTAMP) 는 “컬럼이 빠졌을 때”만 동작
   - 결과적으로 create_at 이 NULL 로 저장 → Entity 조회 시 null → 오류
- @CreationTimestamp 어노테이션 적용
   - @CreationTimestamp는 Hibernate가 INSERT 직전에 createAt 필드를 현재 시각으로 세팅한다
  
## 📸 스크린샷

## 📢 노트
