### PR TITLE
bug[#30]: POST DELETE 오류

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -99,15 +99,12 @@ public class PostService {
     public void delete(Long id, User user) {
         PostCommon common = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
-        if (!(common instanceof Found found)) {
-            throw new IllegalArgumentException("해당 게시물은 FOUND 타입이 아닙니다.");
-        }
 
         // 게시글 작성자와 현재 로그인한 사용자가 일치하는지 확인
-        if (!found.getUser().getId().equals(user.getId())) {
+        if (!common.getUser().getId().equals(user.getId())) {
             throw new RuntimeException("게시글 작성자만 삭제할 수 있습니다.");
         }
 
-        postRepository.delete(found);
+        postRepository.delete(common);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #30 

## 💬 리뷰 포인트
> Found 형태의 게시글만 삭제되도록 IF문이 있음을 확인해 삭제함

## 🚀 상세 설명
> POST 작성 시 반환되는 ID로 삭제를 요청했으나 500 오류가 뜨는 상황이 발생
→ 코드를 확인했더니 Found 형태의 게시글만 삭제되도록 IF문이 있음을 확인
→ common 게시글을 통합적으로 삭제하도록 변경