### PR TITLE
[FEAT #22] 외부 구조동물 API 동기화 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	testImplementation 'io.projectreactor:reactor-test'
 	runtimeOnly     'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly     'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -42,6 +44,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/duckdns/petfinderapp/PetfinderappApplication.java
+++ b/src/main/java/org/duckdns/petfinderapp/PetfinderappApplication.java
@@ -2,10 +2,14 @@ package org.duckdns.petfinderapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@EnableScheduling
 @EnableJpaAuditing
+@SpringBootApplication
+@ConfigurationPropertiesScan(basePackages = "org.duckdns.petfinderapp.domain")
 public class PetfinderappApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
@@ -1,11 +1,18 @@
 package org.duckdns.petfinderapp.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+
 import org.duckdns.petfinderapp.domain.post.enums.NeuterStatus;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @DiscriminatorValue("ADOPT")
@@ -18,24 +25,47 @@ public class Adopt extends PostCommon {
     @Column(name = "animal_num", length = 50)
     private String animalNum;
 
-    private Integer age;
+    private String age;
     private String color;
     private String gender;
 
     @Enumerated(EnumType.STRING)
     private NeuterStatus neuter;
 
-    private Float weight;
+    private Float weight; // 체중 (Kg 단위)
 
     @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+    private LocalDateTime startDate; //공고 시작일
 
     @Column(name = "end_date", nullable = false)
-    private LocalDateTime endDate;
+    private LocalDateTime endDate; //공고 종료일
 
     @Column(name = "shelter_name", length = 50)
     private String shelterName;
 
     @Column(name = "shelter_phone", length = 50)
     private String shelterPhone;
+
+    public void updateWith(Adopt adopt) {
+
+        super.update(
+            adopt.getDate(),
+            adopt.getAddress(),
+            adopt.getCoordinates(),
+            adopt.getPetType(),
+            adopt.getContent(),
+            adopt.getState()
+        );
+
+        this.animalNum = adopt.getAnimalNum();
+        this.age = adopt.getAge();
+        this.color = adopt.getColor();
+        this.gender = adopt.getGender();
+        this.neuter = adopt.getNeuter();
+        this.weight = adopt.getWeight();
+        this.startDate = adopt.getStartDate();
+        this.endDate = adopt.getEndDate();
+        this.shelterName = adopt.getShelterName();
+        this.shelterPhone = adopt.getShelterPhone();
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Image.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Image.java
@@ -1,7 +1,16 @@
 package org.duckdns.petfinderapp.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
@@ -27,5 +36,21 @@ public class Image {
 
         if(!common.getImages().contains(this))
             common.getImages().add(this);
+    }
+
+    public static Image of(String url) {
+        return Image.builder()
+            .origFileName(extractFileName(url))
+            .fileURL(url)
+            .fileSize(null)
+            .build();
+    }
+
+    private static String extractFileName(String url) {
+        int lastSlashIndex = url.lastIndexOf('/');
+        if (lastSlashIndex != -1 && lastSlashIndex < url.length() - 1) {
+            return url.substring(lastSlashIndex + 1);
+        }
+        return "unknown.jpg"; // 기본 파일명
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/PostCommon.java
@@ -1,16 +1,37 @@
 package org.duckdns.petfinderapp.domain.post.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.duckdns.petfinderapp.domain.post.enums.PetType;
 import org.duckdns.petfinderapp.domain.post.enums.PostState;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -26,7 +47,7 @@ public class PostCommon {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+	@JoinColumn(name = "user_id", nullable = true)
     private User user;
 
     @Column(name = "create_at",
@@ -60,7 +81,8 @@ public class PostCommon {
     private PostState state;
 
     @Builder.Default
-    @OneToMany(mappedBy = "common", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	@OneToMany(mappedBy = "common", cascade = {CascadeType.PERSIST,
+		CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Image> images = new ArrayList<>();
 
     public void update(String address, PetType petType, String content, Coordinates coordinates) {
@@ -69,6 +91,16 @@ public class PostCommon {
         this.content = content;
         this.coordinates = coordinates;
     }
+
+	public void update(LocalDateTime data, String address, Coordinates coordinates, PetType petType, String content,
+		PostState state) {
+		this.date = data;
+		this.address = address;
+		this.coordinates = coordinates;
+		this.petType = petType;
+		this.content = content;
+		this.state = state;
+	}
 
     public void clearImages() {
         for (Image image : this.images) {
@@ -87,7 +119,7 @@ public class PostCommon {
     public void addImage(Image image) {
         this.images.add(image);
 
-        if(image.getCommon() != this)
+		if (image.getCommon() != this)
             image.setCommon(this);
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/NeuterStatus.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/NeuterStatus.java
@@ -1,6 +1,23 @@
 package org.duckdns.petfinderapp.domain.post.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum NeuterStatus {
-    NEUTERED,
-    NOT_NEUTERED
+    NEUTERED("Y"),
+    NOT_NEUTERED("N"),
+    UNKNOWN("U");
+
+    private final String apiValue;
+
+    public static NeuterStatus fromApiValue(String value) {
+        for (NeuterStatus status : NeuterStatus.values()) {
+            if (status.getApiValue().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown NeuterStatus value: " + value);
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
@@ -1,7 +1,43 @@
 package org.duckdns.petfinderapp.domain.post.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum PetType {
-    DOG,
-    CAT,
-    ETC
+	DOG("개"),
+	CAT("고양이"),
+	ETC("기타");
+
+	// JSON으로부터 오는 한글(또는 기타 문자열) 값을 담을 필드
+	private final String korean;
+
+	PetType(String korean) {
+		this.korean = korean;
+	}
+
+	/**
+	 * 서버(JSON)로 응답된 문자열(예: "개" 또는 "고양이" 등)을 이 메서드를 통해
+	 * 해당 enum 상수로 변환해 줍니다.
+	 */
+	@JsonCreator
+	public static PetType from(String value) {
+		if (value == null) {
+			return ETC;   // null처리 시 기본값
+		}
+		return switch (value.trim()) {
+			case "개" -> DOG;
+			case "고양이" -> CAT;
+			case "기타" ->   // 혹은 JSON에서 기타 동물은 "기타" 등으로 올 수 있다면
+				ETC;
+			default ->
+				// 만약 JSON에 예상치 못한 문자열이 들어오면
+				// 기본적으로 ETC로 처리하거나, IllegalArgumentException 던질 수도 있음
+				ETC;
+		};
+	}
+
+	@JsonValue
+	public String toJson() {
+		return this.korean;
+	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PostState.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PostState.java
@@ -1,8 +1,22 @@
 package org.duckdns.petfinderapp.domain.post.enums;
 
 public enum PostState {
-    ADOPT,
-    LOST,
-    SIGHT,
-    NOTICE
+	ADOPT,  // 입양 (보호중)
+	LOST,   // 실종
+	SIGHT,  // 목격
+	NOTICE, // 공고
+	END     // 보호종료
+	;
+
+	public static PostState fromString(String state) {
+		if (state == null) {
+			return null;
+		}
+		return switch (state.toLowerCase()) {
+			case "notice" -> NOTICE;
+			case "protect" -> ADOPT;
+			case "finish" -> END;
+			default -> null;
+		};
+	}
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
@@ -1,0 +1,10 @@
+package org.duckdns.petfinderapp.domain.post.repository;
+
+import java.util.List;
+
+import org.duckdns.petfinderapp.domain.post.entity.Adopt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdoptRepository extends JpaRepository<Adopt, Long> {
+	List<Adopt> findAllByAnimalNumIn(List<String> animalNums);
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
@@ -1,10 +1,12 @@
 package org.duckdns.petfinderapp.domain.post.repository;
 
-import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
 public interface PostRepository extends JpaRepository<PostCommon, Long> {
     List<PostCommon> findAllByOrderByIdDesc();
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -1,10 +1,20 @@
 package org.duckdns.petfinderapp.domain.post.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonCreate;
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonUpdate;
 import org.duckdns.petfinderapp.domain.post.dto.response.ResCommon;
-import org.duckdns.petfinderapp.domain.post.entity.*;
+import org.duckdns.petfinderapp.domain.post.entity.Adopt;
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+import org.duckdns.petfinderapp.domain.post.entity.Found;
+import org.duckdns.petfinderapp.domain.post.entity.Image;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.repository.AdoptRepository;
 import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -12,14 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+	private final AdoptRepository adoptRepository;
     private final S3Uploader s3Uploader;
 
     // 게시글 작성
@@ -130,4 +139,31 @@ public class PostService {
 
         postRepository.delete(common);
     }
+
+    @Transactional
+    public Integer upsertAdopts(List<Adopt> newAdoptList) {
+        List<String> newAnimalNums = newAdoptList.stream()
+            .map(Adopt::getAnimalNum)
+            .toList();
+
+        List<Adopt> existingAdopts = adoptRepository.findAllByAnimalNumIn(newAnimalNums);
+
+        Map<String, Adopt> existingMap = existingAdopts.stream()
+            .collect(Collectors.toMap(Adopt::getAnimalNum, Function.identity()));
+
+        List<Adopt> newAdopts = new ArrayList<>();
+
+        for (Adopt newAdopt : newAdoptList) {
+            Adopt existingAdopt = existingMap.get(newAdopt.getAnimalNum());
+            if (existingAdopt != null) {
+                existingAdopt.updateWith(newAdopt);
+            } else {
+                newAdopts.add(newAdopt);
+            }
+        }
+
+        adoptRepository.saveAll(newAdopts);
+        return newAdopts.size();
+    }
+
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/client/PublicDataClient.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/client/PublicDataClient.java
@@ -1,0 +1,104 @@
+package org.duckdns.petfinderapp.domain.publicdata.client;
+
+import java.util.Optional;
+
+import org.duckdns.petfinderapp.domain.publicdata.config.PublicDataProperties;
+import org.duckdns.petfinderapp.domain.publicdata.dto.request.AdoptApiRequest;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.AdoptApiResponse;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.ErrorResponseWrapper;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PublicDataClient {
+
+	private final PublicDataProperties publicDataProperties;
+	private final WebClient publicDataApiWebClient;
+
+	public Mono<AdoptApiResponse> fetchAdopts(AdoptApiRequest request) {
+		return publicDataApiWebClient.get()
+			.uri(uriBuilder ->
+				uriBuilder
+					.path(publicDataProperties.adopt().uri()) // "/abandonmentPublicService_v2/abandonmentPublic_v2"
+					.queryParam("serviceKey", request.serviceKey())
+					.queryParam("_type", "json")
+					.queryParam("numOfRows", request.numberOfRows())
+					.queryParamIfPresent("bgupd", Optional.ofNullable(request.updateDate()))
+					.queryParamIfPresent("state", Optional.ofNullable(request.state()))
+					.build()
+			)
+			.exchangeToMono(resp -> handlePublicDataResponse(resp, AdoptApiResponse.class));
+	}
+
+	private <T> Mono<T> handlePublicDataResponse(
+		ClientResponse response,
+		Class<T> successDtoClass
+	) {
+		MediaType contentType = response.headers().contentType()
+			.orElse(MediaType.APPLICATION_OCTET_STREAM);
+		int statusCode = response.statusCode().value();
+
+		// 1) XML 게이트웨이 오류
+		if (contentType.isCompatibleWith(MediaType.APPLICATION_XML) ||
+			contentType.isCompatibleWith(MediaType.TEXT_XML)) {
+			return response.bodyToMono(String.class)
+				.flatMap(rawXml -> {
+					log.error("API 게이트웨이 오류 XML 응답: status={}, contentType={}, body={}",
+						statusCode, contentType, rawXml);
+					try {
+						XmlMapper xmlMapper = new XmlMapper();
+						ErrorResponseWrapper errorDto =
+							xmlMapper.readValue(rawXml, ErrorResponseWrapper.class);
+
+						int reasonCode = errorDto.cmmMsgHeader().returnReasonCode();
+						String authMsg = errorDto.cmmMsgHeader().returnAuthMsg();
+						String errMsg = errorDto.cmmMsgHeader().errMsg();
+
+						return switch (reasonCode) {
+							case 22, 23 -> {
+								log.warn("요청 제한 초과({}). 잠시 뒤 재시도 필요.", authMsg);
+								yield Mono.empty();
+							}
+							case 30 -> {
+								log.error("서비스키 미등록 에러: {}. serviceKey 확인하세요.", authMsg);
+								yield Mono.error(new RuntimeException("잘못된 서비스키: " + authMsg));
+							}
+							default -> {
+								log.error("알 수 없는 게이트웨이 오류: code={}, msg={}", reasonCode, errMsg);
+								yield Mono.error(new RuntimeException("API 게이트웨이 오류: " + errMsg));
+							}
+						};
+					} catch (Exception e) {
+						log.error("XML 파싱 중 예외 발생: {}", e.getMessage(), e);
+						return Mono.error(new RuntimeException("XML 파싱 오류", e));
+					}
+				});
+		}
+
+		// 2) JSON 정상 응답
+		if (contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+			return response.bodyToMono(successDtoClass)
+				.doOnNext(dto -> log.info("구조 동물 조회 API 응답 성공"))
+				.doOnNext(dto -> log.debug("구조 동물 조회 API 전체 응답: {}", dto))
+				.doOnError(err -> log.error("구조 동물 조회 API JSON 파싱 실패: {}", err.getMessage(), err));
+		}
+
+		// 3) 그 외 예외
+		return response.bodyToMono(String.class)
+			.flatMap(raw -> {
+				log.error("알 수 없는 응답 형식: status={}, contentType={}, body={}",
+					statusCode, contentType, raw);
+				return Mono.error(new RuntimeException("알 수 없는 응답 형식: " + contentType));
+			});
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/client/SgisClient.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/client/SgisClient.java
@@ -1,0 +1,68 @@
+package org.duckdns.petfinderapp.domain.publicdata.client;
+
+import org.duckdns.petfinderapp.domain.publicdata.config.SgisProperties;
+import org.duckdns.petfinderapp.domain.publicdata.dto.request.GeocodingApiRequest;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisAccessTokenResult;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisGeocodingResult;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisResponse;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SgisClient {
+	private final SgisProperties sgisProperties;
+	private final WebClient sgisApiWebClient;
+
+	public Mono<SgisResponse<SgisGeocodingResult>> fetchCoordinatesByAddress(GeocodingApiRequest request) {
+		return sgisApiWebClient.get()
+			.uri(uriBuilder ->
+				uriBuilder
+					.path(sgisProperties.geocoding().uri())
+					.queryParam("accessToken", request.accessToken())
+					.queryParam("address", request.address())
+					.build()
+			)
+			.exchangeToMono(resp -> {
+				if (resp.statusCode().is2xxSuccessful()) {
+					return resp.bodyToMono(new ParameterizedTypeReference<>() {
+					});
+				} else {
+					return resp.bodyToMono(String.class)
+						.flatMap(body -> {
+							log.error("SGIS API 오류 응답: status={} body={}", resp.statusCode(), body);
+							return Mono.error(new RuntimeException("SGIS API 요청 실패: " + resp.statusCode()));
+						});
+				}
+			});
+	}
+
+	public Mono<SgisResponse<SgisAccessTokenResult>> fetchSgisAccessToken() {
+		return sgisApiWebClient.get()
+			.uri(uriBuilder ->
+				uriBuilder
+					.path(sgisProperties.auth().uri())
+					.queryParam("consumer_key", sgisProperties.auth().key())
+					.queryParam("consumer_secret", sgisProperties.auth().secret())
+					.build()
+			)
+			.exchangeToMono(resp -> {
+				if (resp.statusCode().is2xxSuccessful()) {
+					return resp.bodyToMono(new ParameterizedTypeReference<>() {
+					});
+				} else {
+					return resp.bodyToMono(String.class)
+						.flatMap(body -> {
+							log.error("SGIS API 오류 응답: status={} body={}", resp.statusCode(), body);
+							return Mono.error(new RuntimeException("SGIS API 요청 실패: " + resp.statusCode()));
+						});
+				}
+			});
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/PublicDataConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/PublicDataConfig.java
@@ -1,0 +1,61 @@
+package org.duckdns.petfinderapp.domain.publicdata.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class PublicDataConfig {
+
+	private static final int MAX_BUFFER_SIZE = 2 * 1024 * 1024; // 2MB
+	private final SgisProperties sgisProperties;
+	private final PublicDataProperties publicDataProperties;
+
+	/**
+	 * PublicData(유기동물 조회 등) 전용 WebClient
+	 */
+	@Bean
+	public WebClient publicDataApiWebClient(WebClient.Builder builder) {
+		DefaultUriBuilderFactory factory =
+			new DefaultUriBuilderFactory(publicDataProperties.baseUrl());
+		factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+
+		return builder
+			.uriBuilderFactory(factory)
+			.baseUrl(publicDataProperties.baseUrl())
+			.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+			.exchangeStrategies(ExchangeStrategies.builder()
+				.codecs(configurer ->
+					configurer.defaultCodecs()
+						.maxInMemorySize(MAX_BUFFER_SIZE)
+				)
+				.build()
+			)
+			.build();
+	}
+
+	/**
+	 * SGIS API 전용 WebClient
+	 */
+	@Bean
+	public WebClient sgisApiWebClient(WebClient.Builder builder) {
+		return builder
+			.baseUrl(sgisProperties.baseUrl())
+			.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+			.exchangeStrategies(ExchangeStrategies.builder()
+				.codecs(configurer ->
+					configurer.defaultCodecs()
+						.maxInMemorySize(MAX_BUFFER_SIZE)
+				)
+				.build()
+			)
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/PublicDataProperties.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/PublicDataProperties.java
@@ -1,0 +1,16 @@
+package org.duckdns.petfinderapp.domain.publicdata.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "public-data")
+public record PublicDataProperties(
+	String baseUrl,
+	ApiProperties adopt
+) {
+
+	public record ApiProperties(
+		String uri,
+		String key
+	) {
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/SgisProperties.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/config/SgisProperties.java
@@ -1,0 +1,22 @@
+package org.duckdns.petfinderapp.domain.publicdata.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sgis")
+public record SgisProperties(
+	String baseUrl,
+	Geocoding geocoding,
+	Auth auth
+) {
+	public record Geocoding(
+		String uri
+	) {
+	}
+
+	public record Auth(
+		String uri,
+		String key,
+		String secret
+	) {
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/request/AdoptApiRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/request/AdoptApiRequest.java
@@ -1,0 +1,34 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.request;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record AdoptApiRequest(
+	@NotBlank
+	String serviceKey,
+	String state,
+	String updateDate,
+	Integer numberOfRows
+) {
+
+	public static AdoptApiRequest forLatest(String serviceKey, Integer numberOfRows) {
+		return AdoptApiRequest.builder()
+			.serviceKey(serviceKey)
+			.numberOfRows(numberOfRows)
+			.build();
+	}
+
+	public static AdoptApiRequest forState(String serviceKey, String state, Integer numberOfRows) {
+		return AdoptApiRequest.builder()
+			.serviceKey(serviceKey)
+			.state(state)
+			.updateDate(
+				LocalDateTime.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+			.numberOfRows(numberOfRows)
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/request/GeocodingApiRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/request/GeocodingApiRequest.java
@@ -1,0 +1,19 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record GeocodingApiRequest(
+	String accessToken, // String, 필수, 액세스토큰
+	String address, // String, 필수, 검색주소
+	Integer pagenum, // default: 0, 선택, 페이지
+	Integer resultcount // min: 1 max: 50 (default: 5), 선택, 결과 수
+) {
+
+	public static GeocodingApiRequest of(String accessToken, String address) {
+		return GeocodingApiRequest.builder()
+			.accessToken(accessToken)
+			.address(address)
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptApiResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptApiResponse.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AdoptApiResponse(
+	PublicDataResponse<AdoptItem> response
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
@@ -1,0 +1,143 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.duckdns.petfinderapp.domain.post.entity.Adopt;
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+import org.duckdns.petfinderapp.domain.post.entity.Image;
+import org.duckdns.petfinderapp.domain.post.enums.NeuterStatus;
+import org.duckdns.petfinderapp.domain.post.enums.PetType;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+/**
+ * 구조 동물 상세 정보 DTO (주요 필드만 포함)
+ */
+@Builder
+public record AdoptItem(
+	@NotBlank
+	String desertionNo,   // 구조번호
+	@NotBlank
+	String age,           // 나이 (예: 2025(60일미만)(년생))
+	@NotBlank
+	String colorCd,       // 색상
+	@NotBlank
+	String sexCd,         // 성별 (M: 수컷, F: 암컷, Q: 미상)
+	@NotBlank
+	String neuterYn,      // 중성화 여부 (Y: 예, N: 아니오, U: 미상)
+	@NotBlank
+	String weight,        // 체중 (예: 0.11(Kg))
+	@NotBlank
+	String noticeSdt,     // 공고시작일(YYYYMMDD)
+	@NotBlank
+	String noticeEdt,     // 공고종료일(YYYYMMDD)
+	@NotBlank
+	String careNm,        // 보호소이름
+	@NotBlank
+	String careTel,       // 보호소전화번호
+	@NotBlank
+	String careRegNo,     // 보호소번호
+	@NotBlank
+	String happenDt,      // 접수일(YYYYMMDD)
+	@NotBlank
+	String happenPlace,   // 발견장소
+	@NotNull
+	PetType upKindNm,      // 축종명 (예: 고양이)
+	@NotBlank
+	String specialMark,   // 특징
+	String popfile1,      // 이미지1 URL
+	String popfile2,      // 이미지2 URL
+	String popfile3,      // 이미지3 URL
+	String popfile4,      // 이미지4 URL
+	String popfile5,      // 이미지5 URL
+	String popfile6,      // 이미지6 URL
+	String popfile7,      // 이미지7 URL
+	String popfile8,      // 이미지8 URL
+	//        String upKindCd,      // 축종코드 (개: 417000, 고양이: 422400, 기타: 429900)
+	//        String kindFullNm,    // 품종 ([축종] 품종명)
+	//        String kindCd,        // 품종코드
+	//        String kindNm,        // 품종명 (예: 한국 고양이)
+	//        String noticeNo,      // 공고번호
+	//        String processState,  // 상태 (예: 보호중)
+	//        String careOwnerNm,   // 보호소대표자
+	String careAddr,      // 보호장소
+	String orgNm         // 관할기관
+	//        String updTm          // 수정일(yyyy-mm-dd hh:mm:ss)
+) {
+	private static LocalDateTime parseToLocalDateTime(String dateStr) {
+		return LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
+	}
+
+	public Adopt toAdopt(Coordinates coordinates) {
+		Adopt adopt = Adopt.builder()
+			.animalNum(desertionNo)
+			.age(age)
+			.color(colorCd)
+			.gender(sexCd)
+			.neuter(NeuterStatus.fromApiValue(neuterYn))
+			.weight(weight != null ? Float.parseFloat(weight.replace("(Kg)", "").trim()) : null)
+			.startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
+			.endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
+			.shelterName(careNm)
+			.shelterPhone(careTel)
+			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
+			.address(happenPlace)
+			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
+			.petType(upKindNm) // 축종명은 PetType으로 변환 필요
+			.content(specialMark)
+			.state(parseToLocalDateTime(noticeEdt).isAfter(LocalDateTime.now())
+				? PostState.NOTICE : PostState.ADOPT) // 상태 정보는 API 응답에 포함되지 않음
+			.build();
+
+		getImageUrls().stream()
+			.map(Image::of)
+			.forEach(image -> image.setCommon(adopt)); // Adopt와 연결
+
+		return adopt;
+	}
+
+	public Adopt toAdopt(PostState postState, Coordinates coordinates) {
+		Adopt adopt = Adopt.builder()
+			.animalNum(desertionNo)
+			.age(age)
+			.color(colorCd)
+			.gender(sexCd)
+			.neuter(NeuterStatus.fromApiValue(neuterYn))
+			.weight(weight != null ? Float.parseFloat(weight.replace("(Kg)", "").replace(",", ".").trim()) : null)
+			.startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
+			.endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
+			.shelterName(careNm)
+			.shelterPhone(careTel)
+			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
+			.address(happenPlace)
+			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
+			.petType(upKindNm) // 축종명은 PetType으로 변환 필요
+			.content(specialMark)
+			.state(postState) // 상태 정보는 API 응답에 포함되지 않음
+			.build();
+
+		getImageUrls().stream()
+			.map(Image::of)
+			.forEach(image -> image.setCommon(adopt)); // Adopt와 연결
+
+		return adopt;
+	}
+
+	public List<String> getImageUrls() {
+		return Stream.of(popfile1, popfile2, popfile3, popfile4,
+				popfile5, popfile6, popfile7, popfile8)
+			.filter(Objects::nonNull)       // null 제거
+			.map(String::trim)              // 앞뒤 공백 제거
+			.filter(s -> !s.isEmpty())      // 빈 문자열 제거
+			.toList();                      // Java 16+: toList(), 그 이전 버전은 collect(Collectors.toList())
+	}
+
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/ErrorResponseWrapper.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/ErrorResponseWrapper.java
@@ -1,0 +1,22 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+@JacksonXmlRootElement(localName = "OpenAPI_ServiceResponse")
+public record ErrorResponseWrapper(
+	@JacksonXmlProperty(localName = "cmmMsgHeader")
+	CmmMsgHeader cmmMsgHeader
+) {
+	public record CmmMsgHeader(
+		@JacksonXmlProperty(localName = "errMsg")
+		String errMsg,
+
+		@JacksonXmlProperty(localName = "returnAuthMsg")
+		String returnAuthMsg,
+
+		@JacksonXmlProperty(localName = "returnReasonCode")
+		int returnReasonCode
+	) {
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/ItemWrapper.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/ItemWrapper.java
@@ -1,0 +1,8 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import java.util.List;
+
+public record ItemWrapper<T>(
+	List<T> item
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataBodyResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataBodyResponse.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+public record PublicDataBodyResponse<T>(
+	ItemWrapper<T> items,
+	Integer numOfRows,
+	Integer pageNo,
+	Integer totalCount
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataHeaderResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataHeaderResponse.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+public record PublicDataHeaderResponse(
+	String reqNo,
+	String resultCode,
+	String resultMsg,
+	String errorMsg
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/PublicDataResponse.java
@@ -1,0 +1,7 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+public record PublicDataResponse<T>(
+	PublicDataHeaderResponse header,
+	PublicDataBodyResponse<T> body
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisAccessTokenResult.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisAccessTokenResult.java
@@ -1,0 +1,7 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+public record SgisAccessTokenResult(
+	String accessToken,
+	Long accessTimeout
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisGeocodingItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisGeocodingItem.java
@@ -1,0 +1,15 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+
+public record SgisGeocodingItem(
+	Double x,
+	Double y
+) {
+	public Coordinates toCoordinates() {
+		return Coordinates.builder()
+			.latitude(y)
+			.longitude(x)
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisGeocodingResult.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisGeocodingResult.java
@@ -1,0 +1,12 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+import java.util.List;
+
+public record SgisGeocodingResult(
+	String totalcount,
+	List<SgisGeocodingItem> resultdata,
+	String matching,
+	String pagenum,
+	String returncount
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/SgisResponse.java
@@ -1,0 +1,10 @@
+package org.duckdns.petfinderapp.domain.publicdata.dto.response;
+
+public record SgisResponse<T>(
+	String id,
+	T result,
+	String errMsg,
+	Integer errCd,
+	String trId
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/scheduler/PublicDataScheduler.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/scheduler/PublicDataScheduler.java
@@ -1,0 +1,33 @@
+package org.duckdns.petfinderapp.domain.publicdata.scheduler;
+
+import org.duckdns.petfinderapp.domain.publicdata.service.AdoptSyncService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PublicDataScheduler {
+	private final AdoptSyncService adoptSyncService;
+
+	// 5분마다 구조 동물 데이터를 추가하는 스케줄러
+	@Scheduled(fixedRate = 5 * 60 * 1000) // 매 5분마다
+	public void addAdopts() {
+		log.info("구조 동물을 추가합니다.");
+		adoptSyncService.addNewAdopts()
+			.doOnError(e -> log.error("구조 동물 데이터 추가 중 에러 발생:", e))
+			.subscribe();
+	}
+
+	// 매일 오전 2시에 전날 수정된 구조 동물 데이터를 갱신하는 스케줄러
+	@Scheduled(cron = "0 0 2 * * ?") // 매일 오전 2시
+	public void updateAllAdopts() {
+		log.info("전체 구조 동물 데이터를 갱신합니다.");
+		adoptSyncService.refreshAllAdopts()
+			.doOnError(e -> log.error("전체 구조 동물 데이터 갱신 중 에러 발생:", e))
+			.subscribe();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncService.java
@@ -1,0 +1,11 @@
+package org.duckdns.petfinderapp.domain.publicdata.service;
+
+import reactor.core.publisher.Mono;
+
+public interface AdoptSyncService {
+	/** 최근 공고만 추가 저장 (incremental sync) */
+	Mono<Void> addNewAdopts();
+
+	/** 전체 데이터 갱신 (full sync) */
+	Mono<Void> refreshAllAdopts();
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncServiceImpl.java
@@ -1,0 +1,184 @@
+package org.duckdns.petfinderapp.domain.publicdata.service;
+
+import java.util.List;
+
+import org.duckdns.petfinderapp.domain.post.entity.Adopt;
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+import org.duckdns.petfinderapp.domain.post.service.PostService;
+import org.duckdns.petfinderapp.domain.publicdata.client.PublicDataClient;
+import org.duckdns.petfinderapp.domain.publicdata.client.SgisClient;
+import org.duckdns.petfinderapp.domain.publicdata.config.PublicDataProperties;
+import org.duckdns.petfinderapp.domain.publicdata.dto.request.AdoptApiRequest;
+import org.duckdns.petfinderapp.domain.publicdata.dto.request.GeocodingApiRequest;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.AdoptApiResponse;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.AdoptItem;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.PublicDataBodyResponse;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisGeocodingItem;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisGeocodingResult;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisResponse;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdoptSyncServiceImpl implements AdoptSyncService {
+
+	private static final int NEW_FETCH_SIZE = 100;
+	private static final int FULL_FETCH_SIZE = 1000;
+	private static final List<String> STATES = List.of("notice", "protect", "finish");
+
+	private final PublicDataClient publicDataClient;
+	private final PublicDataProperties publicDataProperties;
+	private final SgisClient sgisClient;
+	private final PostService postService;
+	private final SgisTokenService sgisTokenService;
+
+	@Override
+	public Mono<Void> addNewAdopts() {
+		return fetchAdoptItems(NEW_FETCH_SIZE)
+			.flatMapSequential(this::convertToAdoptWithCoordinates)
+			.collectList()
+			.flatMap(this::saveAdopts);
+	}
+
+	@Override
+	public Mono<Void> refreshAllAdopts() {
+		return Flux.merge(
+				STATES.stream()
+					.map(this::fetchAdoptItemsByState)
+					.toList()
+			)
+			.collectList()
+			.flatMap(adopts -> {
+				log.info("전체 입양 동물 데이터 갱신 완료 - 총 {}건", adopts.size());
+				return saveAdopts(adopts);
+			})
+			.onErrorResume(e -> {
+				log.error("전체 입양 동물 데이터 갱신 중 에러 발생", e);
+				return Mono.empty();
+			});
+	}
+
+	private Flux<Adopt> fetchAdoptItemsByState(String state) {
+		return fetchAdoptItems(state, FULL_FETCH_SIZE)
+			.doOnSubscribe(s -> log.info("상태 '{}' 공고 조회 시작 ({}건)", state, FULL_FETCH_SIZE))
+			.doOnComplete(() -> log.info("상태 '{}' 공고 조회 완료", state))
+			.onErrorResume(e -> {
+				log.error("상태 '{}' 공고 조회 중 에러 발생", state, e);
+				return Flux.empty();
+			})
+			.flatMapSequential(item -> {
+				PostState postState = PostState.fromString(state);
+				if (postState == null) {
+					log.warn("알 수 없는 상태 '{}' -> 스킵 (desertionNo={})", state, item.desertionNo());
+					return Mono.empty();
+				}
+				return convertToAdoptWithCoordinates(item, postState);
+			});
+	}
+
+	private Flux<AdoptItem> fetchAdoptItems(int fetchSize) {
+		AdoptApiRequest request = AdoptApiRequest.forLatest(
+			publicDataProperties.adopt().key(), fetchSize
+		);
+		return publicDataClient.fetchAdopts(request)
+			.flatMapMany(this::extractAdoptItems);
+	}
+
+	private Flux<AdoptItem> fetchAdoptItems(String state, int fetchSize) {
+		AdoptApiRequest request = AdoptApiRequest.forState(
+			publicDataProperties.adopt().key(), state, fetchSize
+		);
+		return publicDataClient.fetchAdopts(request)
+			.flatMapMany(this::extractAdoptItems);
+	}
+
+	private Flux<AdoptItem> extractAdoptItems(AdoptApiResponse response) {
+		try {
+			PublicDataBodyResponse<AdoptItem> body = response.response().body();
+			if (body == null || body.items() == null || body.items().item() == null) {
+				return Flux.empty();
+			}
+			List<AdoptItem> items = body.items().item();
+			return items.isEmpty() ? Flux.empty() : Flux.fromIterable(items);
+		} catch (Exception e) {
+			log.warn("입양 동물 데이터 추출 실패", e);
+			return Flux.empty();
+		}
+	}
+
+	private Mono<Adopt> convertToAdoptWithCoordinates(AdoptItem item) {
+		return getCoordinatesForAddress(item)
+			.map(item::toAdopt)
+			.doOnNext(a -> log.debug("변환 완료: {}", item.desertionNo()))
+			.onErrorResume(e -> {
+				log.warn("좌표 변환 실패 - 번호: {}, 주소: {}", item.desertionNo(), item.happenPlace(), e);
+				return Mono.empty();
+			});
+	}
+
+	private Mono<Adopt> convertToAdoptWithCoordinates(AdoptItem item, PostState state) {
+		return getCoordinatesForAddress(item)
+			.map(coords -> item.toAdopt(state, coords))
+			.doOnNext(a -> log.debug("변환 완료: {}", item.desertionNo()))
+			.onErrorResume(e -> {
+				log.warn("좌표 변환 실패 - 번호: {}, 주소: {}", item.desertionNo(), item.happenPlace(), e);
+				return Mono.empty();
+			});
+	}
+
+	private Mono<Coordinates> getCoordinatesForAddress(AdoptItem item) {
+		return sgisTokenService.getAccessToken()
+			.flatMap(token -> {
+				Mono<Coordinates> byPlace = callGeocodingApi(token, item.happenPlace())
+					.flatMap(this::extractCoordinates);
+				String combined = item.orgNm() + ' ' + item.happenPlace();
+				Mono<Coordinates> byOrg = callGeocodingApi(token, combined)
+					.flatMap(this::extractCoordinates);
+				return byPlace.switchIfEmpty(byOrg)
+					.switchIfEmpty(Mono.defer(() -> {
+						log.warn("지오코딩 실패: '{}' / '{}' 결과 없음", item.happenPlace(), combined);
+						return Mono.empty();
+					}));
+			});
+	}
+
+	private Mono<SgisResponse<SgisGeocodingResult>> callGeocodingApi(String token, String address) {
+		GeocodingApiRequest req = GeocodingApiRequest.of(token, address);
+		return sgisClient.fetchCoordinatesByAddress(req)
+			.doOnNext(resp -> log.debug("지오코딩 응답 - 주소: {}, 결과: {}", address, resp));
+	}
+
+	private Mono<Coordinates> extractCoordinates(SgisResponse<SgisGeocodingResult> resp) {
+		try {
+			SgisGeocodingResult result = resp.result();
+			if (result == null || result.resultdata() == null || result.resultdata().isEmpty()) {
+				return Mono.empty();
+			}
+			SgisGeocodingItem geo = result.resultdata().get(0);
+			return Mono.just(geo.toCoordinates());
+		} catch (Exception e) {
+			log.warn("좌표 추출 실패", e);
+			return Mono.empty();
+		}
+	}
+
+	private Mono<Void> saveAdopts(List<Adopt> adopts) {
+		if (adopts.isEmpty()) {
+			log.info("저장할 데이터 없음");
+			return Mono.empty();
+		}
+		log.info("입양 동물 데이터 저장 시작 - 총 {}건", adopts.size());
+		return Mono.fromCallable(() -> postService.upsertAdopts(adopts))
+			.publishOn(Schedulers.boundedElastic())
+			.doOnSuccess(count -> log.info("저장 완료 - 추가된 {}건", count))
+			.then();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/SgisTokenService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/SgisTokenService.java
@@ -1,0 +1,75 @@
+package org.duckdns.petfinderapp.domain.publicdata.service;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.PostConstruct;
+
+import org.duckdns.petfinderapp.domain.publicdata.client.SgisClient;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisAccessTokenResult;
+import org.duckdns.petfinderapp.domain.publicdata.dto.response.SgisResponse;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SgisTokenService {
+
+	private final SgisClient sgisClient;
+
+	// 현재 메모리에 저장된 액세스 토큰과 만료 시각
+	private final AtomicReference<String> currentToken = new AtomicReference<>(null);
+	private final AtomicReference<Instant> tokenExpiryTime = new AtomicReference<>(Instant.EPOCH);
+
+	/**
+	 * 애플리케이션 시작 직후, 토큰을 한 번 미리 받아두기
+	 */
+	@PostConstruct
+	public void initializeToken() {
+		log.info("애플리케이션 시작: SGIS 액세스 토큰 최초 요청");
+		refreshToken()
+			.subscribeOn(Schedulers.boundedElastic())
+			.doOnError(e -> log.error("초기 토큰 요청 실패", e))
+			.subscribe();
+	}
+
+	/**
+	 * 토큰을 SGIS API에서 가져와 currentToken과 tokenExpiryTime을 갱신한다.
+	 */
+	public Mono<Void> refreshToken() {
+		return sgisClient.fetchSgisAccessToken()
+			.flatMap((SgisResponse<SgisAccessTokenResult> resp) -> {
+				// SGIS 응답 구조에 맞춰, 첫번째 아이템에서 실제 토큰 문자열을 꺼낸다고 가정
+				SgisAccessTokenResult tokenItem = resp.result();
+				String accessToken = tokenItem.accessToken();
+				Instant expiresAt = Instant.ofEpochMilli(tokenItem.accessTimeout());
+
+				currentToken.set(accessToken);
+				tokenExpiryTime.set(expiresAt);
+
+				log.info("SGIS 액세스 토큰 갱신 완료, 만료시간: {}", expiresAt);
+				return Mono.empty();
+			});
+	}
+
+	/**
+	 * 현재 저장된 토큰을 반환. 토큰이 없거나 만료 임박(30초 이내)이면 즉시 refreshToken()을 실행하고 새 토큰을 반환.
+	 */
+	public Mono<String> getAccessToken() {
+		String token = currentToken.get();
+		Instant expiresAt = tokenExpiryTime.get();
+
+		if (token == null || Instant.now().isAfter(expiresAt.minusSeconds(30))) {
+			log.info("토큰 없음 또는 곧 만료({}) 예정. 새 토큰 조회", expiresAt);
+			return refreshToken()
+				.then(Mono.fromSupplier(currentToken::get));
+		}
+
+		return Mono.just(token);
+	}
+}


### PR DESCRIPTION
좋아요. 구조동물 데이터를 외부 API로부터 동기화하고, 이를 기반으로 프론트엔드 노출까지 가능한 기능을 구현한 PR로 정리할게요. 곧 작성해드릴게요.


## 📌 이슈 번호

\#22

## 💬 리뷰 포인트

* 외부 공공데이터 포털 **구조동물 API 연동** 및 **응답 데이터 파싱** 처리
* **구조동물 정보 도메인 엔티티**(`Adopt` 등) 설계 및 **저장 전략** 구현
* **주소→좌표 변환**을 위한 **SGIS API 연동** 및 **액세스 토큰 관리**
* 구조동물 **신규 추가** 및 **전체 갱신 스케줄러** 구현
* `WebClient` 및 관련 설정 추가

## 🚀 상세 설명

* 공공데이터 포털의 유기동물 조회 API를 **비동기로 호출**하는 클라이언트(`PublicDataClient`)를 구현하였으며, XML 응답의 오류 상황에 대한 처리 로직도 포함했습니다.
* **SGIS API 연동**을 통해 구조동물 발견 장소(주소)를 **위도/경도 좌표로 변환**하는 기능을 추가했습니다. 이와 함께 `SgisClient` 및 `SgisTokenService`를 도입하여 **SGIS 액세스 토큰 관리** 기능도 구현했습니다.
* 외부 API 응답 데이터를 DTO인 `AdoptItem`으로 매핑한 뒤 `Adopt` 엔티티로 변환하며, 이 과정에서 **좌표 정보와 이미지 리스트**도 함께 구성하도록 처리했습니다.
* 수집한 구조동물 데이터가 기존 DB에 **중복되지 않도록**, `PostService.upsertAdopts` 메서드를 사용하여 **Upsert(삽입 또는 갱신)** 방식으로 데이터를 통합했습니다.
* **스케줄러(`PublicDataScheduler`) 구현:** 신규 구조동물 데이터를 **5분마다 동기화**하고, 매일 **새벽 2시 전체 데이터 갱신** 작업을 수행하도록 설정했습니다.
* **엔티티 변경사항:** `Adopt`, `PostCommon`, `Image` 엔티티에 여러 주요 필드가 추가되었고, **상태 변경**을 처리하는 메서드들이 새롭게 도입되었습니다.
* 또한 `PetType`, `PostState`, `NeuterStatus` 등의 **ENUM 클래스에 외부 API 값과의 매핑 로직** 및 편의 메서드를 추가하여, API 응답 값을 바로 해당 ENUM으로 변환할 수 있도록 하였습니다.

## 📸 스크린샷

(필요시 추후 추가)

## 📢 노트
