### PR TITLE
[Fix #35]: Adopt 매핑 오류 해결

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
@@ -22,6 +22,9 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class Adopt extends PostCommon {
 
+    @Column(name = "desertion_no", nullable = false, length = 50, unique = true)
+    private String desertionNum; // 구조번호
+
     @Column(name = "animal_num", length = 50)
     private String animalNum;
 
@@ -57,6 +60,7 @@ public class Adopt extends PostCommon {
             adopt.getState()
         );
 
+        this.desertionNum = adopt.getDesertionNum();
         this.animalNum = adopt.getAnimalNum();
         this.age = adopt.getAge();
         this.color = adopt.getColor();

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
@@ -6,5 +6,5 @@ import org.duckdns.petfinderapp.domain.post.entity.Adopt;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdoptRepository extends JpaRepository<Adopt, Long> {
-	List<Adopt> findAllByAnimalNumIn(List<String> animalNums);
+	List<Adopt> findAllByDesertionNumIn(List<String> animalNums);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -142,19 +142,19 @@ public class PostService {
 
     @Transactional
     public Integer upsertAdopts(List<Adopt> newAdoptList) {
-        List<String> newAnimalNums = newAdoptList.stream()
-            .map(Adopt::getAnimalNum)
+        List<String> newDesertionNum = newAdoptList.stream()
+            .map(Adopt::getDesertionNum)
             .toList();
 
-        List<Adopt> existingAdopts = adoptRepository.findAllByAnimalNumIn(newAnimalNums);
+        List<Adopt> existingAdopts = adoptRepository.findAllByDesertionNumIn(newDesertionNum);
 
         Map<String, Adopt> existingMap = existingAdopts.stream()
-            .collect(Collectors.toMap(Adopt::getAnimalNum, Function.identity()));
+            .collect(Collectors.toMap(Adopt::getDesertionNum, Function.identity()));
 
         List<Adopt> newAdopts = new ArrayList<>();
 
         for (Adopt newAdopt : newAdoptList) {
-            Adopt existingAdopt = existingMap.get(newAdopt.getAnimalNum());
+            Adopt existingAdopt = existingMap.get(newAdopt.getDesertionNum());
             if (existingAdopt != null) {
                 existingAdopt.updateWith(newAdopt);
             } else {

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
@@ -25,6 +25,9 @@ import lombok.Builder;
 public record AdoptItem(
 	@NotBlank
 	String desertionNo,   // 구조번호
+
+	String rfidCd, // 동물등록번호(RFID 코드, 예: 123456789012345)
+
 	@NotBlank
 	String age,           // 나이 (예: 2025(60일미만)(년생))
 	@NotBlank
@@ -78,7 +81,8 @@ public record AdoptItem(
 
 	public Adopt toAdopt(Coordinates coordinates) {
 		Adopt adopt = Adopt.builder()
-			.animalNum(desertionNo)
+			.desertionNum(desertionNo)
+			.animalNum(rfidCd)
 			.age(age)
 			.color(colorCd)
 			.gender(sexCd)


### PR DESCRIPTION
## 📌 이슈 번호

\#35

## 💬 리뷰 포인트

* `Adopt` 엔티티에 구조번호(`desertionNum`) 필드 추가 및 고유 제약 조건 적용
* Adopt 조회 Repository 메서드를 `animalNum` → `desertionNum` 기준으로 수정
* `PostService#upsertAdopts` 로직에서 식별자 비교 키를 `animalNum` → `desertionNum` 으로 변경
* 외부 API DTO(`AdoptItem`) 변환 로직에서 필드 매핑 오류 수정 (`desertionNo` → `desertionNum`, `rfidCd` → `animalNum`)

## 🚀 상세 설명

1. **Adopt 엔티티**

   * `desertionNum` 컬럼을 추가하고 `nullable=false`, `length=50`, `unique=true` 제약조건 설정
   * 기존 `animalNum` 필드는 그대로 유지하되, 구조번호와 동물등록번호를 분리
   * `updateWith` 메서드에 `this.desertionNum = adopt.getDesertionNum()` 구문 추가

2. **AdoptRepository 수정**

   * 기존 `findAllByAnimalNumIn(List<String> animalNums)` 시그니처를
     `findAllByDesertionNumIn(List<String> desertionNums)` 로 변경하여
     구조번호를 기준으로 배치 조회 가능하도록 수정

3. **PostService#upsertAdopts 로직 변경**

   * 입력 리스트에서 추출하는 키를 `newAnimalNums = …getAnimalNum()` 에서
     `newDesertionNum = …getDesertionNum()` 으로 변경
   * 기존 데이터 조회(`existingAdopts`)도 `findAllByDesertionNumIn` 호출하도록 수정
   * Map 키도 `Adopt::getDesertionNum` 으로 매핑하여 업데이트 및 신규 처리 로직 정합성 확보

4. **AdoptItem DTO 변환 로직 보정**

   * `AdoptItem` 레코드의 필드 선언부에서 `desertionNo` 를 `desertionNo` 그대로 두고,
     `rfidCd` 를 `animalNum` 으로 매핑하도록 `toAdopt()` 내부 빌더 호출 순서를 수정

## 📸 스크린샷


## 📢 노트
