### PR TITLE
[FEAT #37]: 지도 검색 기능 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -1,11 +1,13 @@
 package org.duckdns.petfinderapp.domain.map.controller;
 
+import jakarta.validation.constraints.Size;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.map.service.MapService;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,15 +15,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequestMapping("/map")
 @RequiredArgsConstructor
 public class MapController {
-	private final MapService mapService;
 
-	@GetMapping("/search")
-	public ApiResponse<Page<MapSearchResponse>> mapSearch(@RequestParam String query, Pageable pageable) {
-		Page<MapSearchResponse> data = mapService.mapSearch(query, pageable);
-		return ApiResponse.onSuccess(HttpStatus.OK, "검색 성공", data);
-	}
+  private final MapService mapService;
+
+  @GetMapping("/search")
+  public ApiResponse<Page<MapSearchResponse>> mapSearch(
+      @Size(min = 15, max = 15, message = "동물등록번호는 15자리입니다.")
+      @RequestParam String query,
+      Pageable pageable) {
+    Page<MapSearchResponse> data = mapService.mapSearch(query, pageable);
+    return ApiResponse.onSuccess(HttpStatus.OK, "검색 성공", data);
+  }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -1,5 +1,6 @@
 package org.duckdns.petfinderapp.domain.map.controller;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.map.service.MapService;
@@ -26,6 +27,7 @@ public class MapController {
   @GetMapping("/search")
   public ApiResponse<Page<MapSearchResponse>> mapSearch(
       @Size(min = 15, max = 15, message = "동물등록번호는 15자리입니다.")
+      @NotBlank
       @RequestParam String query,
       Pageable pageable) {
     Page<MapSearchResponse> data = mapService.mapSearch(query, pageable);

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -1,0 +1,27 @@
+package org.duckdns.petfinderapp.domain.map.controller;
+
+import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
+import org.duckdns.petfinderapp.domain.map.service.MapService;
+import org.duckdns.petfinderapp.global.template.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/map")
+@RequiredArgsConstructor
+public class MapController {
+	private final MapService mapService;
+
+	@GetMapping("/search")
+	public ApiResponse<Page<MapSearchResponse>> mapSearch(@RequestParam String query, Pageable pageable) {
+		Page<MapSearchResponse> data = mapService.mapSearch(query, pageable);
+		return ApiResponse.onSuccess(HttpStatus.OK, "검색 성공", data);
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapSearchResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapSearchResponse.java
@@ -1,0 +1,28 @@
+package org.duckdns.petfinderapp.domain.map.dto.response;
+
+import org.duckdns.petfinderapp.domain.post.entity.Adopt;
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+import org.duckdns.petfinderapp.domain.post.entity.Lost;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+
+import lombok.Builder;
+
+@Builder
+public record MapSearchResponse(
+	Long id, // 게시글 ID
+	String name, // 동물등록번호
+	String address, // 주소
+	Coordinates coordinates // 좌표
+) {
+	public static MapSearchResponse of(PostCommon postCommon) {
+		String petNum = postCommon instanceof Adopt ?
+			((Adopt)postCommon).getPetNum() : ((Lost)postCommon).getPetNum();
+
+		return MapSearchResponse.builder()
+			.id(postCommon.getId())
+			.name(petNum)
+			.address(postCommon.getAddress())
+			.coordinates(postCommon.getCoordinates())
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
@@ -1,0 +1,9 @@
+package org.duckdns.petfinderapp.domain.map.service;
+
+import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MapService {
+	Page<MapSearchResponse> mapSearch(String query, Pageable pageable);
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -1,0 +1,21 @@
+package org.duckdns.petfinderapp.domain.map.service;
+
+import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
+import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MapServiceImpl implements MapService {
+	private final PostRepository postRepository;
+
+	@Override
+	public Page<MapSearchResponse> mapSearch(String query, Pageable pageable) {
+		return postRepository.findAdoptOrLostByPetNum(query, pageable)
+			.map(MapSearchResponse::of);
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
@@ -25,8 +25,8 @@ public class Adopt extends PostCommon {
     @Column(name = "desertion_no", nullable = false, length = 50, unique = true)
     private String desertionNum; // 구조번호
 
-    @Column(name = "animal_num", length = 50)
-    private String animalNum;
+    @Column(name = "pet_num", length = 50)
+    private String petNum;
 
     private String age;
     private String color;
@@ -61,7 +61,7 @@ public class Adopt extends PostCommon {
         );
 
         this.desertionNum = adopt.getDesertionNum();
-        this.animalNum = adopt.getAnimalNum();
+        this.petNum = adopt.getPetNum();
         this.age = adopt.getAge();
         this.color = adopt.getColor();
         this.gender = adopt.getGender();

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/AdoptRepository.java
@@ -6,5 +6,5 @@ import org.duckdns.petfinderapp.domain.post.entity.Adopt;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdoptRepository extends JpaRepository<Adopt, Long> {
-	List<Adopt> findAllByDesertionNumIn(List<String> animalNums);
+	List<Adopt> findAllByDesertionNumIn(List<String> newDesertionNumList);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
@@ -3,10 +3,22 @@ package org.duckdns.petfinderapp.domain.post.repository;
 import java.util.List;
 
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<PostCommon, Long> {
     List<PostCommon> findAllByOrderByIdDesc();
+
+    @Query(
+        value = "select p from PostCommon p"
+            + " where treat(p as Adopt).petNum = :petNum"
+            + " or treat(p as Lost).petNum = :petNum",
+        countQuery = "select count(p) from PostCommon p"
+            + " where treat(p as Adopt).petNum = :petNum"
+            + " or treat(p as Lost).petNum = :petNum")
+    Page<PostCommon> findAdoptOrLostByPetNum(String petNum, Pageable pageable);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -142,11 +142,11 @@ public class PostService {
 
     @Transactional
     public Integer upsertAdopts(List<Adopt> newAdoptList) {
-        List<String> newDesertionNum = newAdoptList.stream()
+        List<String> newDesertionNumList = newAdoptList.stream()
             .map(Adopt::getDesertionNum)
             .toList();
 
-        List<Adopt> existingAdopts = adoptRepository.findAllByDesertionNumIn(newDesertionNum);
+        List<Adopt> existingAdopts = adoptRepository.findAllByDesertionNumIn(newDesertionNumList);
 
         Map<String, Adopt> existingMap = existingAdopts.stream()
             .collect(Collectors.toMap(Adopt::getDesertionNum, Function.identity()));

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
@@ -82,7 +82,7 @@ public record AdoptItem(
 	public Adopt toAdopt(Coordinates coordinates) {
 		Adopt adopt = Adopt.builder()
 			.desertionNum(desertionNo)
-			.animalNum(rfidCd)
+			.petNum(rfidCd)
 			.age(age)
 			.color(colorCd)
 			.gender(sexCd)
@@ -110,7 +110,8 @@ public record AdoptItem(
 
 	public Adopt toAdopt(PostState postState, Coordinates coordinates) {
 		Adopt adopt = Adopt.builder()
-			.animalNum(desertionNo)
+			.desertionNum(desertionNo)
+			.petNum(rfidCd)
 			.age(age)
 			.color(colorCd)
 			.gender(sexCd)

--- a/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
@@ -1,8 +1,12 @@
 package org.duckdns.petfinderapp.global.error;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.duckdns.petfinderapp.global.error.exception.BaseException;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
@@ -18,49 +22,73 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException ex) {
-        log.error("Error [{}]: {}", ex.getStatus().value(), ex.getMessage(), ex);
-        ApiResponse<Void> body = ApiResponse.onFailure(
-                ex.getStatus(),
-                ex.getMessage()
-        );
-        return ResponseEntity
-                .status(ex.getStatus())
-                .body(body);
-    }
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(
+      ConstraintViolationException ex) {
+    Set<ConstraintViolation<?>> constraintViolations = ex.getConstraintViolations();
+    Map<String, String> errors = constraintViolations.stream()
+        .collect(Collectors.toMap(
+            v -> v.getPropertyPath().toString()
+            , ConstraintViolation::getMessage,
+            (existing, replacement) -> existing + ", " + replacement
+        ));
 
-    // 1) DTO 검증 실패 잡기
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(
-        MethodArgumentNotValidException ex
-    ) {
-        Map<String, String> errors = new HashMap<>();
-        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
-            errors.put(error.getField(), error.getDefaultMessage());
-        }
-        log.warn("Validation failed: {}", errors);
+    log.warn("Validation failed: {}", errors);
 
-        ApiResponse<Map<String, String>> body = ApiResponse.onFailure(
-            HttpStatus.BAD_REQUEST,
-            "입력 값이 유효하지 않습니다.",
-            errors    // ApiResponse에 data(payload) 필드를 지원해야 합니다.
-        );
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(body);
-    }
+    ApiResponse<Map<String, String>> body = ApiResponse.onFailure(
+        HttpStatus.BAD_REQUEST,
+        "입력 값이 유효하지 않습니다.",
+        errors
+    );
 
-    // 2) 그 외 모든 예외는 500 Internal Server Error
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleOtherException(Exception ex) {
-        log.error("[UnhandledException] ", ex);
-        ApiResponse<Void> body = ApiResponse.onFailure(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "서버 오류가 발생했습니다."
-        );
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(body);
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(body);
+  }
+
+  @ExceptionHandler(BaseException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException ex) {
+    log.error("Error [{}]: {}", ex.getStatus().value(), ex.getMessage(), ex);
+    ApiResponse<Void> body = ApiResponse.onFailure(
+        ex.getStatus(),
+        ex.getMessage()
+    );
+    return ResponseEntity
+        .status(ex.getStatus())
+        .body(body);
+  }
+
+  // 1) DTO 검증 실패 잡기
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(
+      MethodArgumentNotValidException ex
+  ) {
+    Map<String, String> errors = new HashMap<>();
+    for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+      errors.put(error.getField(), error.getDefaultMessage());
     }
+    log.warn("Validation failed: {}", errors);
+
+    ApiResponse<Map<String, String>> body = ApiResponse.onFailure(
+        HttpStatus.BAD_REQUEST,
+        "입력 값이 유효하지 않습니다.",
+        errors    // ApiResponse에 data(payload) 필드를 지원해야 합니다.
+    );
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(body);
+  }
+
+  // 2) 그 외 모든 예외는 500 Internal Server Error
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse<Void>> handleOtherException(Exception ex) {
+    log.error("[UnhandledException] ", ex);
+    ApiResponse<Void> body = ApiResponse.onFailure(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        "서버 오류가 발생했습니다."
+    );
+    return ResponseEntity
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(body);
+  }
 }

--- a/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,6 +22,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleMissingParam(
+      MissingServletRequestParameterException ex) {
+
+    Map<String, String> errors = Map.of(
+        ex.getParameterName(),
+        "필수 요청 파라미터 '" + ex.getParameterName() + "'가 누락되었습니다."
+    );
+
+    ApiResponse<Map<String, String>> body =
+        ApiResponse.onFailure(HttpStatus.BAD_REQUEST,
+            "필수 요청 파라미터가 누락되었습니다",
+            errors);
+
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(body);
+  }
 
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(

--- a/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
@@ -20,57 +20,59 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RestAuthenticationEntryPoint entryPoint;
-	private final RestAccessDeniedHandler accessDeniedHandler;
-	private final UserRepository userRepository;
-	private final TokenBlackListService blackListService;
 
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-			.cors(Customizer.withDefaults())
-			// CSRF 완전 비활성화
-			.csrf(AbstractHttpConfigurer::disable)
-			// stateless 세션 정책
-			.sessionManagement(sm -> sm
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-			)
-			.exceptionHandling(ex -> ex
-				.authenticationEntryPoint(entryPoint)
-				.accessDeniedHandler(accessDeniedHandler)
-			)
-			// 권한 검사 설정
-			.authorizeHttpRequests(auth -> auth
-				// 카카오 로그인 엔드포인트는 인증 없이 허용
-				.requestMatchers(
-					"/auth/login/kakao",
-					"/ws/**"
-				).permitAll()
-				// 그 외의 모든 요청은 인증 필요
-				.anyRequest().authenticated()
-			)
-		;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final RestAuthenticationEntryPoint entryPoint;
+  private final RestAccessDeniedHandler accessDeniedHandler;
+  private final UserRepository userRepository;
+  private final TokenBlackListService blackListService;
 
-			// JWT 필터 적용
-		http.addFilterBefore(
-			new JwtAuthenticationFilter(jwtTokenProvider, userRepository, blackListService),
-			UsernamePasswordAuthenticationFilter.class
-		);
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .cors(Customizer.withDefaults())
+        // CSRF 완전 비활성화
+        .csrf(AbstractHttpConfigurer::disable)
+        // stateless 세션 정책
+        .sessionManagement(sm -> sm
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        )
+        .exceptionHandling(ex -> ex
+            .authenticationEntryPoint(entryPoint)
+            .accessDeniedHandler(accessDeniedHandler)
+        )
+        // 권한 검사 설정
+        .authorizeHttpRequests(auth -> auth
+            // 카카오 로그인 엔드포인트는 인증 없이 허용
+            .requestMatchers(
+                "/auth/login/kakao",
+                "/ws/**",
+                "/map/search"
+            ).permitAll()
+            // 그 외의 모든 요청은 인증 필요
+            .anyRequest().authenticated()
+        )
+    ;
 
-		return http.build();
-	}
+    // JWT 필터 적용
+    http.addFilterBefore(
+        new JwtAuthenticationFilter(jwtTokenProvider, userRepository, blackListService),
+        UsernamePasswordAuthenticationFilter.class
+    );
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration config = new CorsConfiguration();
-		config.setAllowedOriginPatterns(List.of("*"));
-		config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS", "WEBSOCKET"));
-		config.setAllowedHeaders(List.of("*"));
-		config.setAllowCredentials(true);
+    return http.build();
+  }
 
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", config);
-		return source;
-	}
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOriginPatterns(List.of("*"));
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "WEBSOCKET"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
 }

--- a/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/security/SecurityConfig.java
@@ -46,8 +46,7 @@ public class SecurityConfig {
             // 카카오 로그인 엔드포인트는 인증 없이 허용
             .requestMatchers(
                 "/auth/login/kakao",
-                "/ws/**",
-                "/map/search"
+                "/ws/**"
             ).permitAll()
             // 그 외의 모든 요청은 인증 필요
             .anyRequest().authenticated()


### PR DESCRIPTION
## 📌 이슈 번호

\#37

## 💬 리뷰 포인트

* 동물등록번호 기반 지도 검색 API 구현
* **검색어 유효성 검사 (15자리 동물등록번호만 허용) 및 필수 파라미터 누락 시 예외 처리 추가**
* 도메인 전반에 걸쳐 `petNum` 용어 통일

## 🚀 상세 설명

* `/map/search` **GET** API를 추가하여 **동물등록번호**로 입양 및 실종 게시글을 검색할 수 있도록 구현했습니다.
* `MapController`, `MapService`, `MapSearchResponse` 등의 클래스와 DTO를 새로 생성했습니다.
* 입력값 **유효성 검사**를 통해 **15자리 등록번호**만 허용하며, 필수 파라미터 (`query`)가 누락된 경우 **예외 응답**을 반환하도록 처리했습니다.
* `GlobalExceptionHandler`에 `MissingServletRequestParameterException`, `ConstraintViolationException` **핸들러**를 추가하여 오류 메시지를 보다 상세하게 제공하도록 개선했습니다.

## 📸 스크린샷

## 📢 노트