### PR TITLE
[FEAT #39] 지도 범위 기반 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -1,7 +1,10 @@
 package org.duckdns.petfinderapp.domain.map.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.map.service.MapService;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
@@ -32,5 +35,15 @@ public class MapController {
       Pageable pageable) {
     Page<MapSearchResponse> data = mapService.mapSearch(query, pageable);
     return ApiResponse.onSuccess(HttpStatus.OK, "검색 성공", data);
+  }
+
+  @GetMapping("/posts")
+  public ApiResponse<Page<MapPostsResponse>> getPostsByCoordinates(
+      @Valid MapPostRequest mapPostRequest,
+      Pageable pageable) {
+    Page<MapPostsResponse> data = mapService.getPostsByCoordinates(
+        mapPostRequest, pageable);
+
+    return ApiResponse.onSuccess(HttpStatus.OK, "게시글 조회 성공", data);
   }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapPostRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapPostRequest.java
@@ -1,0 +1,30 @@
+package org.duckdns.petfinderapp.domain.map.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import java.util.List;
+import org.duckdns.petfinderapp.domain.post.enums.PetType;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public record MapPostRequest(
+    @RequestParam double minLat,
+    @RequestParam double maxLat,
+    @RequestParam double minLng,
+    @RequestParam double maxLng,
+    @RequestParam(required = false) List<PostState> states,
+    @RequestParam(required = false) List<PetType> species
+){
+  @AssertTrue(message = "coordinate가 유효하지 않습니다")
+  public boolean isValidCoordinates() {
+    // 최소 위도(minLat)는 최대 위도(maxLat)보다 커야 하고,
+    // 최소 경도(minLng)와 최대 경도(maxLng)보다 커야 합니다.
+    if (minLat > maxLat || minLng > maxLng) {
+      return false;
+    }
+    // 위도는 -90도에서 90도 사이, 경도는 -180도에서 180도 사이여야 합니다.
+    if (minLat < -90 || maxLat > 90 || minLng < -180 || maxLng > 180) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapPostsResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapPostsResponse.java
@@ -1,0 +1,27 @@
+package org.duckdns.petfinderapp.domain.map.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+
+@Builder
+public record MapPostsResponse(
+    String postId,
+    PostState state,
+    LocalDateTime date,
+    String address,
+    String description,
+    String imageUrl
+) {
+  public static MapPostsResponse of(PostCommon postCommon, String thumbnailImageUrl) {
+    return MapPostsResponse.builder()
+        .postId(postCommon.getId().toString())
+        .state(postCommon.getState())
+        .date(postCommon.getDate())
+        .address(postCommon.getAddress())
+        .description(postCommon.getContent())
+        .imageUrl(thumbnailImageUrl)
+        .build();
+  }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
@@ -1,9 +1,16 @@
 package org.duckdns.petfinderapp.domain.map.service;
 
+import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface MapService {
-	Page<MapSearchResponse> mapSearch(String query, Pageable pageable);
+
+  Page<MapSearchResponse> mapSearch(String query, Pageable pageable);
+
+  Page<MapPostsResponse> getPostsByCoordinates(
+      MapPostRequest mapPostRequest,
+      Pageable pageable);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -1,21 +1,58 @@
 package org.duckdns.petfinderapp.domain.map.service;
 
+import jakarta.persistence.criteria.Predicate;
+import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
 import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MapServiceImpl implements MapService {
-	private final PostRepository postRepository;
 
-	@Override
-	public Page<MapSearchResponse> mapSearch(String query, Pageable pageable) {
-		return postRepository.findAdoptOrLostByPetNum(query, pageable)
-			.map(MapSearchResponse::of);
-	}
+  private final PostRepository postRepository;
+
+  @Override
+  public Page<MapSearchResponse> mapSearch(String query, Pageable pageable) {
+    return postRepository.findAdoptOrLostByPetNum(query, pageable)
+        .map(MapSearchResponse::of);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<MapPostsResponse> getPostsByCoordinates(
+      MapPostRequest mapPostRequest,
+      Pageable pageable) {
+
+    // 1) states 또는 species 가 null 이거나 비어있으면 -> 결과 없음
+    if (mapPostRequest.states() == null || mapPostRequest.states().isEmpty()
+        || mapPostRequest.species() == null || mapPostRequest.species().isEmpty()) {
+      return Page.empty(pageable);
+    }
+
+    Specification<PostCommon> spec = ((root, query, criteriaBuilder) -> {
+      Predicate latBetween = criteriaBuilder.between(
+          root.get("coordinates").get("latitude"), mapPostRequest.minLat(), mapPostRequest.maxLat());
+      Predicate lngBetween = criteriaBuilder.between(
+          root.get("coordinates").get("longitude"), mapPostRequest.minLng(), mapPostRequest.maxLng());
+      Predicate stateIn = root.get("state").in(mapPostRequest.states());
+      Predicate speciesIn = root.get("petType").in(mapPostRequest.species());
+      Predicate notEndPost = criteriaBuilder.notEqual(
+          root.get("state"), PostState.END);
+
+      return criteriaBuilder.and(latBetween, lngBetween, stateIn, speciesIn, notEndPost);
+    });
+
+    return postRepository.findAll(spec, pageable)
+        .map(postCommon -> MapPostsResponse.of(postCommon, postCommon.getImages().get(0).getFileURL()));
+  }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
@@ -6,11 +6,12 @@ import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<PostCommon, Long> {
+public interface PostRepository extends JpaRepository<PostCommon, Long>, JpaSpecificationExecutor<PostCommon> {
     List<PostCommon> findAllByOrderByIdDesc();
 
     @Query(


### PR DESCRIPTION
## 📌 이슈 번호

\#39

## 💬 리뷰 포인트

* 위도/경도 범위 기반 지도 영역 필터링 쿼리 적용
* 요청 값 유효성 검증(좌표 범위 오류 등) 및 예외 처리
* 필터 조건 누락 시 빈 페이지 반환 처리

## 🚀 상세 설명

* `/map/posts` GET API를 추가하여 지도 좌표 및 필터 조건에 맞는 게시글을 조회할 수 있도록 구현했습니다.
* `MapPostRequest` DTO를 통해 위도/경도 범위와 선택적 필터값(PostState, PetType)을 전달받아 처리합니다.
* 좌표 유효성 검증을 위한 `@AssertTrue`을 추가하여 잘못된 범위 입력을 사전에 차단합니다.
* 서비스 레이어(`MapServiceImpl`)에서 JPA Specification을 활용해 쿼리를 구성하였습니다.
* 응답 객체로 `MapPostsResponse`를 새로 정의하여 게시글 ID, 상태, 날짜, 주소, 요약 설명, 대표 이미지 URL 등을 제공하도록 했습니다.
* `PostRepository`에 `JpaSpecificationExecutor`를 구현하여 복잡한 조건 조합에 대한 동적 쿼리 생성을 지원했습니다.

## 📸 스크린샷

## 📢 노트