### PR TITLE
[FEAT #41]지도 마커 조회 기능 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -3,9 +3,11 @@ package org.duckdns.petfinderapp.domain.map.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
 import org.duckdns.petfinderapp.domain.map.service.MapService;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
 import org.springframework.data.domain.Page;
@@ -45,5 +47,13 @@ public class MapController {
         mapPostRequest, pageable);
 
     return ApiResponse.onSuccess(HttpStatus.OK, "게시글 조회 성공", data);
+  }
+
+  @GetMapping("/markers")
+  public ApiResponse<MapMarkerResponse> getMarkersByCoordinates(@Valid MapMarkerRequest mapMarkerRequest) {
+    MapMarkerResponse data = mapService.getMarkersByCoordinates(
+        mapMarkerRequest);
+
+    return ApiResponse.onSuccess(HttpStatus.OK, "마커 조회 성공", data);
   }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/item/MarkerItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/item/MarkerItem.java
@@ -1,0 +1,29 @@
+package org.duckdns.petfinderapp.domain.map.dto.item;
+
+import lombok.Builder;
+import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.enums.PetType;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+
+@Builder
+public record MarkerItem (
+    Long postId,
+    String address,
+    PostState state,
+    PetType species,
+    Coordinates coordinate,
+    String imageUrl
+){
+
+  public static MarkerItem of(PostCommon postCommon, String fileURL) {
+    return MarkerItem.builder()
+        .postId(postCommon.getId())
+        .address(postCommon.getAddress())
+        .state(postCommon.getState())
+        .species(postCommon.getPetType())
+        .coordinate(postCommon.getCoordinates())
+        .imageUrl(fileURL)
+        .build();
+  }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapMarkerRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapMarkerRequest.java
@@ -1,0 +1,31 @@
+package org.duckdns.petfinderapp.domain.map.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import java.util.List;
+import org.duckdns.petfinderapp.domain.post.enums.PetType;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public record MapMarkerRequest(
+    @RequestParam double minLat,
+    @RequestParam double maxLat,
+    @RequestParam double minLng,
+    @RequestParam double maxLng,
+    @RequestParam(required = false) List<PostState> states,
+    @RequestParam(required = false) List<PetType> species
+){
+  @AssertTrue(message = "coordinate가 유효하지 않습니다")
+  public boolean isValidCoordinates() {
+    // 최소 위도(minLat)는 최대 위도(maxLat)보다 커야 하고,
+    // 최소 경도(minLng)와 최대 경도(maxLng)보다 커야 합니다.
+    if (minLat > maxLat || minLng > maxLng) {
+      return false;
+    }
+    // 위도는 -90도에서 90도 사이, 경도는 -180도에서 180도 사이여야 합니다.
+    if (minLat < -90 || maxLat > 90 || minLng < -180 || maxLng > 180) {
+      return false;
+    }
+    return true;
+  }
+}
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapMarkerResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/response/MapMarkerResponse.java
@@ -1,0 +1,18 @@
+package org.duckdns.petfinderapp.domain.map.dto.response;
+
+import java.util.List;
+import org.duckdns.petfinderapp.domain.map.dto.item.MarkerItem;
+
+public record MapMarkerResponse(
+    List<MarkerItem> markers
+) {
+
+
+  public static MapMarkerResponse empty() {
+    return new MapMarkerResponse(List.of());
+  }
+
+  public static MapMarkerResponse from(List<MarkerItem> markerItemList) {
+    return new MapMarkerResponse(markerItemList);
+  }
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
@@ -1,6 +1,8 @@
 package org.duckdns.petfinderapp.domain.map.service;
 
+import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.springframework.data.domain.Page;
@@ -13,4 +15,6 @@ public interface MapService {
   Page<MapPostsResponse> getPostsByCoordinates(
       MapPostRequest mapPostRequest,
       Pageable pageable);
+
+  MapMarkerResponse getMarkersByCoordinates(MapMarkerRequest mapMarkerRequest);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -1,7 +1,11 @@
 package org.duckdns.petfinderapp.domain.map.service;
 
 import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+import org.duckdns.petfinderapp.domain.map.dto.item.MarkerItem;
+import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
+import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
@@ -54,5 +58,35 @@ public class MapServiceImpl implements MapService {
 
     return postRepository.findAll(spec, pageable)
         .map(postCommon -> MapPostsResponse.of(postCommon, postCommon.getImages().get(0).getFileURL()));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public MapMarkerResponse getMarkersByCoordinates(MapMarkerRequest mapMarkerRequest) {
+
+    // 1) states 또는 species 가 null 이거나 비어있으면 -> 결과 없음
+    if (mapMarkerRequest.states() == null || mapMarkerRequest.states().isEmpty()
+        || mapMarkerRequest.species() == null || mapMarkerRequest.species().isEmpty()) {
+      return MapMarkerResponse.empty();
+    }
+
+    Specification<PostCommon> spec = ((root, query, criteriaBuilder) -> {
+      Predicate latBetween = criteriaBuilder.between(
+          root.get("coordinates").get("latitude"), mapMarkerRequest.minLat(), mapMarkerRequest.maxLat());
+      Predicate lngBetween = criteriaBuilder.between(
+          root.get("coordinates").get("longitude"), mapMarkerRequest.minLng(), mapMarkerRequest.maxLng());
+      Predicate stateIn = root.get("state").in(mapMarkerRequest.states());
+      Predicate speciesIn = root.get("petType").in(mapMarkerRequest.species());
+      Predicate notEndPost = criteriaBuilder.notEqual(
+          root.get("state"), PostState.END);
+
+      return criteriaBuilder.and(latBetween, lngBetween, stateIn, speciesIn, notEndPost);
+    });
+
+    List<MarkerItem> markerItemList = postRepository.findAll(spec).stream()
+        .map(postCommon -> MarkerItem.of(postCommon, postCommon.getImages().get(0).getFileURL()))
+        .toList();
+
+    return MapMarkerResponse.from(markerItemList);
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호

\#41

## 💬 리뷰 포인트

* 마커 응답 전용 DTO 및 응답 포맷 설계
* 좌표 범위 기반 필터링 로직 적용
* 유효하지 않은 요청(필터 없음 등)에 대한 처리

## 🚀 상세 설명

* `/map/markers` GET API를 추가하여 지도 좌표 및 필터 조건에 따른 마커 정보를 반환합니다.
* `MapMarkerRequest`를 통해 위도/경도 범위와 선택적 필터값(PostState, PetType)을 전달받습니다.
* 유효하지 않은 좌표 범위에 대한 검사(@AssertTrue) 로직을 추가하여 사전 검증을 강화했습니다.
* 요청 조건 중 상태 또는 종 필터가 비어있을 경우 빈 마커 응답(`MapMarkerResponse.empty()`)을 반환합니다.
* 응답 객체로 `MapMarkerResponse`, 내부 아이템 객체로 `MarkerItem`을 정의해 마커 ID, 주소, 상태, 종, 좌표, 이미지 정보를 제공합니다.
* 마커에 사용할 대표 이미지는 게시글의 첫 번째 이미지를 기준으로 반환됩니다.

## 📸 스크린샷

## 📢 노트

* 클라이언트는 지도에서 범위 필터를 구성하여 해당 영역에 포함된 게시글 마커만 조회할 수 있습니다.
* 마커용 응답 구조는 성능과 네트워크 효율을 고려해 요약된 정보를 제공합니다.
