### PR TITLE
[Fix #43] PetType 단순화 및 AdoptItem 축종명 파싱 로직 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/enums/PetType.java
@@ -1,43 +1,7 @@
 package org.duckdns.petfinderapp.domain.post.enums;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum PetType {
-	DOG("개"),
-	CAT("고양이"),
-	ETC("기타");
-
-	// JSON으로부터 오는 한글(또는 기타 문자열) 값을 담을 필드
-	private final String korean;
-
-	PetType(String korean) {
-		this.korean = korean;
-	}
-
-	/**
-	 * 서버(JSON)로 응답된 문자열(예: "개" 또는 "고양이" 등)을 이 메서드를 통해
-	 * 해당 enum 상수로 변환해 줍니다.
-	 */
-	@JsonCreator
-	public static PetType from(String value) {
-		if (value == null) {
-			return ETC;   // null처리 시 기본값
-		}
-		return switch (value.trim()) {
-			case "개" -> DOG;
-			case "고양이" -> CAT;
-			case "기타" ->   // 혹은 JSON에서 기타 동물은 "기타" 등으로 올 수 있다면
-				ETC;
-			default ->
-				// 만약 JSON에 예상치 못한 문자열이 들어오면
-				// 기본적으로 ETC로 처리하거나, IllegalArgumentException 던질 수도 있음
-				ETC;
-		};
-	}
-
-	@JsonValue
-	public String toJson() {
-		return this.korean;
-	}
+	DOG,
+	CAT,
+	ETC
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
@@ -53,7 +53,7 @@ public record AdoptItem(
 	@NotBlank
 	String happenPlace,   // 발견장소
 	@NotNull
-	PetType upKindNm,      // 축종명 (예: 고양이)
+	String upKindNm,      // 축종명 (예: 고양이)
 	@NotBlank
 	String specialMark,   // 특징
 	String popfile1,      // 이미지1 URL
@@ -79,6 +79,15 @@ public record AdoptItem(
 		return LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
 	}
 
+	private static PetType parsePetType(String upKindNm) {
+		return switch (upKindNm) {
+			case "개" -> PetType.DOG;
+			case "고양이" -> PetType.CAT;
+			case "기타" -> PetType.ETC;
+			default -> throw new IllegalArgumentException("알 수 없는 축종명: " + upKindNm);
+		};
+	}
+
 	public Adopt toAdopt(Coordinates coordinates) {
 		Adopt adopt = Adopt.builder()
 			.desertionNum(desertionNo)
@@ -95,7 +104,7 @@ public record AdoptItem(
 			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
 			.address(happenPlace)
 			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
-			.petType(upKindNm) // 축종명은 PetType으로 변환 필요
+			.petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
 			.content(specialMark)
 			.state(parseToLocalDateTime(noticeEdt).isAfter(LocalDateTime.now())
 				? PostState.NOTICE : PostState.ADOPT) // 상태 정보는 API 응답에 포함되지 않음
@@ -124,7 +133,7 @@ public record AdoptItem(
 			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
 			.address(happenPlace)
 			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
-			.petType(upKindNm) // 축종명은 PetType으로 변환 필요
+			.petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
 			.content(specialMark)
 			.state(postState) // 상태 정보는 API 응답에 포함되지 않음
 			.build();


### PR DESCRIPTION
## 📌 이슈 번호

\#43

## 💬 리뷰 포인트

* `PetType` enum 단순화 및 JSON 매핑 어노테이션 제거
* `AdoptItem` DTO에서 `upKindNm` 타입을 `PetType` → `String`으로 변경
* `parsePetType` 유틸 메서드 추가 및 `toAdopt()` 내부 변환 로직 적용
* 알 수 없는 축종명에 대한 예외 처리 강화

## 🚀 상세 설명

* **`PetType.java` 리팩토링**

  * 기존에 한글 이름(`korean`), `@JsonCreator`/`@JsonValue`를 통해 문자열 ↔ enum 매핑하던 로직을 제거
  * 단순히 `DOG`, `CAT`, `ETC` 세 가지 상수만 남기고, Jackson 기본 enum 직렬화를 사용하도록 변경

* **`AdoptItem.java` 변경**

  * 외부 공개 API에서 전달되는 축종명(`upKindNm`)을 `PetType` enum이 아닌 `String`으로 받도록 시그니처 수정
  * DTO 내부에 `parsePetType(String upKindNm)` 정적 메서드를 추가하여,

    * `"개"` → `PetType.DOG`
    * `"고양이"` → `PetType.CAT`
    * `"기타"` → `PetType.ETC`
    * 그 외 미지원 값에 대해서는 `IllegalArgumentException`을 던져 사전 검증 강화
  * `toAdopt(Coordinates)` 및 `toAdopt(PostState, Coordinates)` 변환 메서드에서
    `upKindNm` 문자열을 `parsePetType()`으로 변환하여 엔티티에 주입

## 📸 스크린샷

## 📢 노트