### PR TITLE
[FEAT #45] 사용자 게시글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/controller/MapController.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
-import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
+import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
 import org.duckdns.petfinderapp.domain.map.service.MapService;
@@ -40,10 +40,10 @@ public class MapController {
   }
 
   @GetMapping("/posts")
-  public ApiResponse<Page<MapPostsResponse>> getPostsByCoordinates(
+  public ApiResponse<Page<PostSummaryResponse>> getPostsByCoordinates(
       @Valid MapPostRequest mapPostRequest,
       Pageable pageable) {
-    Page<MapPostsResponse> data = mapService.getPostsByCoordinates(
+    Page<PostSummaryResponse> data = mapService.getPostsByCoordinates(
         mapPostRequest, pageable);
 
     return ApiResponse.onSuccess(HttpStatus.OK, "게시글 조회 성공", data);

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapService.java
@@ -3,7 +3,7 @@ package org.duckdns.petfinderapp.domain.map.service;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
-import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
+import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +12,7 @@ public interface MapService {
 
   Page<MapSearchResponse> mapSearch(String query, Pageable pageable);
 
-  Page<MapPostsResponse> getPostsByCoordinates(
+  Page<PostSummaryResponse> getPostsByCoordinates(
       MapPostRequest mapPostRequest,
       Pageable pageable);
 

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -6,7 +6,7 @@ import org.duckdns.petfinderapp.domain.map.dto.item.MarkerItem;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapMarkerRequest;
 import org.duckdns.petfinderapp.domain.map.dto.request.MapPostRequest;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapMarkerResponse;
-import org.duckdns.petfinderapp.domain.map.dto.response.MapPostsResponse;
+import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
 import org.duckdns.petfinderapp.domain.map.dto.response.MapSearchResponse;
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.post.enums.PostState;
@@ -33,7 +33,7 @@ public class MapServiceImpl implements MapService {
 
   @Override
   @Transactional(readOnly = true)
-  public Page<MapPostsResponse> getPostsByCoordinates(
+  public Page<PostSummaryResponse> getPostsByCoordinates(
       MapPostRequest mapPostRequest,
       Pageable pageable) {
 
@@ -45,9 +45,11 @@ public class MapServiceImpl implements MapService {
 
     Specification<PostCommon> spec = ((root, query, criteriaBuilder) -> {
       Predicate latBetween = criteriaBuilder.between(
-          root.get("coordinates").get("latitude"), mapPostRequest.minLat(), mapPostRequest.maxLat());
+          root.get("coordinates").get("latitude"), mapPostRequest.minLat(),
+          mapPostRequest.maxLat());
       Predicate lngBetween = criteriaBuilder.between(
-          root.get("coordinates").get("longitude"), mapPostRequest.minLng(), mapPostRequest.maxLng());
+          root.get("coordinates").get("longitude"), mapPostRequest.minLng(),
+          mapPostRequest.maxLng());
       Predicate stateIn = root.get("state").in(mapPostRequest.states());
       Predicate speciesIn = root.get("petType").in(mapPostRequest.species());
       Predicate notEndPost = criteriaBuilder.notEqual(
@@ -57,7 +59,7 @@ public class MapServiceImpl implements MapService {
     });
 
     return postRepository.findAll(spec, pageable)
-        .map(postCommon -> MapPostsResponse.of(postCommon, postCommon.getImages().get(0).getFileURL()));
+        .map(PostSummaryResponse::of);
   }
 
   @Override
@@ -72,9 +74,11 @@ public class MapServiceImpl implements MapService {
 
     Specification<PostCommon> spec = ((root, query, criteriaBuilder) -> {
       Predicate latBetween = criteriaBuilder.between(
-          root.get("coordinates").get("latitude"), mapMarkerRequest.minLat(), mapMarkerRequest.maxLat());
+          root.get("coordinates").get("latitude"), mapMarkerRequest.minLat(),
+          mapMarkerRequest.maxLat());
       Predicate lngBetween = criteriaBuilder.between(
-          root.get("coordinates").get("longitude"), mapMarkerRequest.minLng(), mapMarkerRequest.maxLng());
+          root.get("coordinates").get("longitude"), mapMarkerRequest.minLng(),
+          mapMarkerRequest.maxLng());
       Predicate stateIn = root.get("state").in(mapMarkerRequest.states());
       Predicate speciesIn = root.get("petType").in(mapMarkerRequest.species());
       Predicate notEndPost = criteriaBuilder.notEqual(

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/PostSummaryResponse.java
@@ -1,4 +1,4 @@
-package org.duckdns.petfinderapp.domain.map.dto.response;
+package org.duckdns.petfinderapp.domain.post.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -6,7 +6,7 @@ import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.post.enums.PostState;
 
 @Builder
-public record MapPostsResponse(
+public record PostSummaryResponse(
     String postId,
     PostState state,
     LocalDateTime date,
@@ -14,14 +14,18 @@ public record MapPostsResponse(
     String description,
     String imageUrl
 ) {
-  public static MapPostsResponse of(PostCommon postCommon, String thumbnailImageUrl) {
-    return MapPostsResponse.builder()
+
+  public static PostSummaryResponse of(PostCommon postCommon) {
+    String imageUrl = postCommon.getImages().isEmpty() ?
+        null : postCommon.getImages().get(0).getFileURL();
+
+    return PostSummaryResponse.builder()
         .postId(postCommon.getId().toString())
         .state(postCommon.getState())
         .date(postCommon.getDate())
         .address(postCommon.getAddress())
         .description(postCommon.getContent())
-        .imageUrl(thumbnailImageUrl)
+        .imageUrl(imageUrl)
         .build();
   }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package org.duckdns.petfinderapp.domain.post.repository;
 import java.util.List;
 
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,15 +12,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<PostCommon, Long>, JpaSpecificationExecutor<PostCommon> {
-    List<PostCommon> findAllByOrderByIdDesc();
+public interface PostRepository extends JpaRepository<PostCommon, Long>,
+    JpaSpecificationExecutor<PostCommon> {
 
-    @Query(
-        value = "select p from PostCommon p"
-            + " where treat(p as Adopt).petNum = :petNum"
-            + " or treat(p as Lost).petNum = :petNum",
-        countQuery = "select count(p) from PostCommon p"
-            + " where treat(p as Adopt).petNum = :petNum"
-            + " or treat(p as Lost).petNum = :petNum")
-    Page<PostCommon> findAdoptOrLostByPetNum(String petNum, Pageable pageable);
+  List<PostCommon> findAllByOrderByIdDesc();
+
+  @Query(
+      value = "select p from PostCommon p"
+          + " where treat(p as Adopt).petNum = :petNum"
+          + " or treat(p as Lost).petNum = :petNum",
+      countQuery = "select count(p) from PostCommon p"
+          + " where treat(p as Adopt).petNum = :petNum"
+          + " or treat(p as Lost).petNum = :petNum")
+  Page<PostCommon> findAdoptOrLostByPetNum(String petNum, Pageable pageable);
+
+  Page<PostCommon> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonCreate;
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonUpdate;
+import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
 import org.duckdns.petfinderapp.domain.post.dto.response.ResCommon;
 import org.duckdns.petfinderapp.domain.post.entity.Adopt;
 import org.duckdns.petfinderapp.domain.post.entity.Coordinates;
@@ -17,6 +18,8 @@ import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.post.repository.AdoptRepository;
 import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,143 +30,147 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class PostService {
-    private final PostRepository postRepository;
-	private final AdoptRepository adoptRepository;
-    private final S3Uploader s3Uploader;
 
-    // 게시글 작성
-    @Transactional
-    public Long create(CommonCreate commonCreate, List<MultipartFile> image, User user) {
-        Found common = commonCreate.toFound(user);
+  private final PostRepository postRepository;
+  private final AdoptRepository adoptRepository;
+  private final S3Uploader s3Uploader;
 
-        if (image != null && !image.isEmpty()) {
-            for (MultipartFile file : image) {
-                try {
-                    // S3에 업로드
-                    String imageUrl = s3Uploader.upload(file, "images");
+  // 게시글 작성
+  @Transactional
+  public Long create(CommonCreate commonCreate, List<MultipartFile> image, User user) {
+    Found common = commonCreate.toFound(user);
 
-                    // 이미지 Entity
-                    Image img = Image.builder()
-                            .origFileName(file.getOriginalFilename())
-                            .fileURL(imageUrl)  // S3 URL 저장
-                            .fileSize(file.getSize())
-                            .build();
+    if (image != null && !image.isEmpty()) {
+      for (MultipartFile file : image) {
+        try {
+          // S3에 업로드
+          String imageUrl = s3Uploader.upload(file, "images");
 
-                    // 게시글에 이미지 추가
-                    common.addImage(img);
+          // 이미지 Entity
+          Image img = Image.builder()
+              .origFileName(file.getOriginalFilename())
+              .fileURL(imageUrl)  // S3 URL 저장
+              .fileSize(file.getSize())
+              .build();
 
-                } catch (IOException e) {
-                    throw new RuntimeException("이미지 업로드 실패: " + file.getOriginalFilename(), e);
-                }
-            }
+          // 게시글에 이미지 추가
+          common.addImage(img);
+
+        } catch (IOException e) {
+          throw new RuntimeException("이미지 업로드 실패: " + file.getOriginalFilename(), e);
         }
-
-        return postRepository.save(common).getId();
+      }
     }
 
-    // Found 조회
-    @Transactional(readOnly = true)
-    public ResCommon searchFound(Long id){
-        PostCommon common = postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
-        if (!(common instanceof Found found)) {
-            throw new IllegalArgumentException("해당 게시물은 FOUND 타입이 아닙니다.");
-        }
-        return ResCommon.of(found);
+    return postRepository.save(common).getId();
+  }
+
+  // Found 조회
+  @Transactional(readOnly = true)
+  public ResCommon searchFound(Long id) {
+    PostCommon common = postRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+    if (!(common instanceof Found found)) {
+      throw new IllegalArgumentException("해당 게시물은 FOUND 타입이 아닙니다.");
+    }
+    return ResCommon.of(found);
+  }
+
+
+  // found 게시글 수정
+  @Transactional
+  public Long update(Long id, CommonUpdate dto, List<MultipartFile> image, User user) {
+    PostCommon common = postRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("해당 게시물이 존재하지 않습니다."));
+    if (!(common instanceof Found found)) {
+      throw new RuntimeException("해당 게시물은 FOUND 타입이 아닙니다.");
     }
 
+    // 게시글 작성자와 현재 로그인한 사용자가 일치하는지 확인
+    if (!found.getUser().getId().equals(user.getId())) {
+      throw new RuntimeException("게시글 작성자만 수정할 수 있습니다.");
+    }
+    Coordinates updateCoordinates = dto.getCoordinates().toEntity();
 
-    // found 게시글 수정
-    @Transactional
-    public Long update(Long id, CommonUpdate dto, List<MultipartFile> image, User user) {
-        PostCommon common = postRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("해당 게시물이 존재하지 않습니다."));
-        if (!(common instanceof Found found)) {
-            throw new RuntimeException("해당 게시물은 FOUND 타입이 아닙니다.");
+    found.update(
+        dto.getAddress(),
+        dto.getPetType(),
+        dto.getContent(),
+        updateCoordinates
+    );
+
+    if (image != null && !image.isEmpty()) {
+      // 기존 이미지 S3에서 삭제
+      List<Image> existingImages = new ArrayList<>(common.getImages());
+      for (Image img : existingImages) {
+        s3Uploader.delete(img.getFileURL());
+      }
+
+      // 새 이미지 목록 생성
+      List<Image> newImages = new ArrayList<>();
+      for (MultipartFile file : image) {
+        try {
+          String imageUrl = s3Uploader.upload(file, "images");
+
+          Image img = Image.builder()
+              .origFileName(file.getOriginalFilename())
+              .fileURL(imageUrl)
+              .fileSize(file.getSize())
+              .build();
+
+          newImages.add(img);
+        } catch (IOException e) {
+          throw new RuntimeException("이미지 업로드 실패: " + file.getOriginalFilename(), e);
         }
+      }
 
-        // 게시글 작성자와 현재 로그인한 사용자가 일치하는지 확인
-        if (!found.getUser().getId().equals(user.getId())) {
-            throw new RuntimeException("게시글 작성자만 수정할 수 있습니다.");
-        }
-        Coordinates updateCoordinates = dto.getCoordinates().toEntity();
-
-        found.update(
-                dto.getAddress(),
-                dto.getPetType(),
-                dto.getContent(),
-                updateCoordinates
-                );
-
-        if (image != null && !image.isEmpty()) {
-            // 기존 이미지 S3에서 삭제
-            List<Image> existingImages = new ArrayList<>(common.getImages());
-            for (Image img : existingImages) {
-                s3Uploader.delete(img.getFileURL());
-            }
-
-            // 새 이미지 목록 생성
-            List<Image> newImages = new ArrayList<>();
-            for (MultipartFile file : image) {
-                try {
-                    String imageUrl = s3Uploader.upload(file, "images");
-
-                    Image img = Image.builder()
-                            .origFileName(file.getOriginalFilename())
-                            .fileURL(imageUrl)
-                            .fileSize(file.getSize())
-                            .build();
-
-                    newImages.add(img);
-                } catch (IOException e) {
-                    throw new RuntimeException("이미지 업로드 실패: " + file.getOriginalFilename(), e);
-                }
-            }
-
-            common.updateImage(newImages);
-        }
-
-        return id;
+      common.updateImage(newImages);
     }
 
-    // 게시글 삭제
-    @Transactional
-    public void delete(Long id, User user) {
-        PostCommon common = postRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
+    return id;
+  }
 
-        // 게시글 작성자와 현재 로그인한 사용자가 일치하는지 확인
-        if (!common.getUser().getId().equals(user.getId())) {
-            throw new RuntimeException("게시글 작성자만 삭제할 수 있습니다.");
-        }
+  // 게시글 삭제
+  @Transactional
+  public void delete(Long id, User user) {
+    PostCommon common = postRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
 
-        postRepository.delete(common);
+    // 게시글 작성자와 현재 로그인한 사용자가 일치하는지 확인
+    if (!common.getUser().getId().equals(user.getId())) {
+      throw new RuntimeException("게시글 작성자만 삭제할 수 있습니다.");
     }
 
-    @Transactional
-    public Integer upsertAdopts(List<Adopt> newAdoptList) {
-        List<String> newDesertionNumList = newAdoptList.stream()
-            .map(Adopt::getDesertionNum)
-            .toList();
+    postRepository.delete(common);
+  }
 
-        List<Adopt> existingAdopts = adoptRepository.findAllByDesertionNumIn(newDesertionNumList);
+  @Transactional
+  public Integer upsertAdopts(List<Adopt> newAdoptList) {
+    List<String> newDesertionNumList = newAdoptList.stream()
+        .map(Adopt::getDesertionNum)
+        .toList();
 
-        Map<String, Adopt> existingMap = existingAdopts.stream()
-            .collect(Collectors.toMap(Adopt::getDesertionNum, Function.identity()));
+    List<Adopt> existingAdopts = adoptRepository.findAllByDesertionNumIn(newDesertionNumList);
 
-        List<Adopt> newAdopts = new ArrayList<>();
+    Map<String, Adopt> existingMap = existingAdopts.stream()
+        .collect(Collectors.toMap(Adopt::getDesertionNum, Function.identity()));
 
-        for (Adopt newAdopt : newAdoptList) {
-            Adopt existingAdopt = existingMap.get(newAdopt.getDesertionNum());
-            if (existingAdopt != null) {
-                existingAdopt.updateWith(newAdopt);
-            } else {
-                newAdopts.add(newAdopt);
-            }
-        }
+    List<Adopt> newAdopts = new ArrayList<>();
 
-        adoptRepository.saveAll(newAdopts);
-        return newAdopts.size();
+    for (Adopt newAdopt : newAdoptList) {
+      Adopt existingAdopt = existingMap.get(newAdopt.getDesertionNum());
+      if (existingAdopt != null) {
+        existingAdopt.updateWith(newAdopt);
+      } else {
+        newAdopts.add(newAdopt);
+      }
     }
 
+    adoptRepository.saveAll(newAdopts);
+    return newAdopts.size();
+  }
+
+  public Page<PostSummaryResponse> getMyPosts(User user, Pageable pageable) {
+    return postRepository.findAllByUser(user, pageable).map(PostSummaryResponse::of);
+  }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package org.duckdns.petfinderapp.domain.user.controller;
 
+import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
+import org.duckdns.petfinderapp.domain.post.service.PostService;
 import org.duckdns.petfinderapp.domain.user.dto.request.UserUpdateRequest;
 import org.duckdns.petfinderapp.domain.user.dto.response.UserInfoResponse;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.duckdns.petfinderapp.domain.user.service.UserService;
 import org.duckdns.petfinderapp.global.template.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
@@ -21,35 +25,49 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/users")
 @RequiredArgsConstructor
 public class UserController {
-	private final UserService userService;
 
-	@GetMapping("/me")
-	public ApiResponse<UserInfoResponse> getCurrentUser(@AuthenticationPrincipal User user) {
-		return ApiResponse.onSuccess(
-			HttpStatus.OK,
-			"내 정보 조회 성공",
-			UserInfoResponse.of(user)
-		);
-	}
+  private final UserService userService;
+  private final PostService postService;
 
-	@PutMapping("/me")
-	public ApiResponse<UserInfoResponse> updateUser(
-		@AuthenticationPrincipal User user,
-		@Validated @RequestBody UserUpdateRequest userUpdateRequest
-	) {
-		UserInfoResponse data = userService.updateUserInfo(user, userUpdateRequest);
-		return ApiResponse.onSuccess(
-			HttpStatus.OK,
-			"내 정보 수정 성공",
-			data
-		);
-	}
+  @GetMapping("/me")
+  public ApiResponse<UserInfoResponse> getCurrentUser(@AuthenticationPrincipal User user) {
+    return ApiResponse.onSuccess(
+        HttpStatus.OK,
+        "내 정보 조회 성공",
+        UserInfoResponse.of(user)
+    );
+  }
 
-	@DeleteMapping("/me")
-	public ApiResponse<Void> deleteUser(
-		@AuthenticationPrincipal User user
-	) {
-		userService.deleteUser(user);
-		return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴 성공", null);
-	}
+  @PutMapping("/me")
+  public ApiResponse<UserInfoResponse> updateUser(
+      @AuthenticationPrincipal User user,
+      @Validated @RequestBody UserUpdateRequest userUpdateRequest
+  ) {
+    UserInfoResponse data = userService.updateUserInfo(user, userUpdateRequest);
+    return ApiResponse.onSuccess(
+        HttpStatus.OK,
+        "내 정보 수정 성공",
+        data
+    );
+  }
+
+  @DeleteMapping("/me")
+  public ApiResponse<Void> deleteUser(
+      @AuthenticationPrincipal User user
+  ) {
+    userService.deleteUser(user);
+    return ApiResponse.onSuccess(HttpStatus.NO_CONTENT, "회원 탈퇴 성공", null);
+  }
+
+  @GetMapping("/me/posts")
+  public ApiResponse<Page<PostSummaryResponse>> getMyPosts(
+      @AuthenticationPrincipal User user,
+      Pageable pageable) {
+    Page<PostSummaryResponse> data = postService.getMyPosts(user, pageable);
+    return ApiResponse.onSuccess(
+        HttpStatus.OK,
+        "내 게시글 조회 성공",
+        data
+    );
+  }
 }


### PR DESCRIPTION
## 📌 이슈 번호

\#45

## 💬 리뷰 포인트

* `MapPostsResponse` → `PostSummaryResponse` 명칭 통일 및 이미지 처리 방식 변경
* `/users/me/posts` 사용자 전용 게시글 조회 API 추가
* 반환 응답 구조(`PostSummaryResponse`) 일관성 확보

## 🚀 상세 설명

* 기존 **지도 게시글 응답 DTO**였던 `MapPostsResponse`를 **도메인 범용 응답 객체**인 `PostSummaryResponse`로 리팩토링했습니다.

  * 게시글 대표 이미지는 없을 경우 `null`로 처리
* **지도 검색 API**(`/map/posts`)에도 새 DTO `PostSummaryResponse`를 적용했습니다.
* **사용자 전용 게시글 조회 API** `/users/me/posts`를 추가하였습니다.

  * 로그인한 사용자의 정보를 기반으로 **본인이 작성한 게시글 목록**을 페이징 형태로 반환합니다.
* `PostService`에 `getMyPosts` 로직을 구현하고, `PostRepository`에 사용자 기반 조회 쿼리를 추가했습니다.
* `UserController`에 신규 엔드포인트(`/users/me/posts`)를 추가하고 해당 서비스(`PostService`)를 주입 처리했습니다.

## 📸 스크린샷


## 📢 노트

* 이제 모든 게시글 응답은 공통 DTO인 `PostSummaryResponse`로 **통일**되었으며, 추후 다른 기능에서도 재사용이 가능합니다.
* 이미지가 존재하지 않을 경우 `imageUrl`은 `null`로 설정되어 **NullPointerException**을 예방합니다.
