### PR TITLE
[Fix #47]: 'species' 파라미터 이름을  'petTypes' 파라미터로 변경

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/item/MarkerItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/item/MarkerItem.java
@@ -11,7 +11,7 @@ public record MarkerItem (
     Long postId,
     String address,
     PostState state,
-    PetType species,
+    PetType petType,
     Coordinates coordinate,
     String imageUrl
 ){
@@ -21,7 +21,7 @@ public record MarkerItem (
         .postId(postCommon.getId())
         .address(postCommon.getAddress())
         .state(postCommon.getState())
-        .species(postCommon.getPetType())
+        .petType(postCommon.getPetType())
         .coordinate(postCommon.getCoordinates())
         .imageUrl(fileURL)
         .build();

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapMarkerRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapMarkerRequest.java
@@ -12,7 +12,7 @@ public record MapMarkerRequest(
     @RequestParam double minLng,
     @RequestParam double maxLng,
     @RequestParam(required = false) List<PostState> states,
-    @RequestParam(required = false) List<PetType> species
+    @RequestParam(required = false) List<PetType> petTypes
 ){
   @AssertTrue(message = "coordinate가 유효하지 않습니다")
   public boolean isValidCoordinates() {

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapPostRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/dto/request/MapPostRequest.java
@@ -12,7 +12,7 @@ public record MapPostRequest(
     @RequestParam double minLng,
     @RequestParam double maxLng,
     @RequestParam(required = false) List<PostState> states,
-    @RequestParam(required = false) List<PetType> species
+    @RequestParam(required = false) List<PetType> petTypes
 ){
   @AssertTrue(message = "coordinate가 유효하지 않습니다")
   public boolean isValidCoordinates() {

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -37,9 +37,9 @@ public class MapServiceImpl implements MapService {
       MapPostRequest mapPostRequest,
       Pageable pageable) {
 
-    // 1) states 또는 species 가 null 이거나 비어있으면 -> 결과 없음
+    // 1) states 또는 petTypes 가 null 이거나 비어있으면 -> 결과 없음
     if (mapPostRequest.states() == null || mapPostRequest.states().isEmpty()
-        || mapPostRequest.species() == null || mapPostRequest.species().isEmpty()) {
+        || mapPostRequest.petTypes() == null || mapPostRequest.petTypes().isEmpty()) {
       return Page.empty(pageable);
     }
 
@@ -51,11 +51,11 @@ public class MapServiceImpl implements MapService {
           root.get("coordinates").get("longitude"), mapPostRequest.minLng(),
           mapPostRequest.maxLng());
       Predicate stateIn = root.get("state").in(mapPostRequest.states());
-      Predicate speciesIn = root.get("petType").in(mapPostRequest.species());
+      Predicate petTypesIn = root.get("petType").in(mapPostRequest.petTypes());
       Predicate notEndPost = criteriaBuilder.notEqual(
           root.get("state"), PostState.END);
 
-      return criteriaBuilder.and(latBetween, lngBetween, stateIn, speciesIn, notEndPost);
+      return criteriaBuilder.and(latBetween, lngBetween, stateIn, petTypesIn, notEndPost);
     });
 
     return postRepository.findAll(spec, pageable)
@@ -66,9 +66,9 @@ public class MapServiceImpl implements MapService {
   @Transactional(readOnly = true)
   public MapMarkerResponse getMarkersByCoordinates(MapMarkerRequest mapMarkerRequest) {
 
-    // 1) states 또는 species 가 null 이거나 비어있으면 -> 결과 없음
+    // 1) states 또는 petTypes 가 null 이거나 비어있으면 -> 결과 없음
     if (mapMarkerRequest.states() == null || mapMarkerRequest.states().isEmpty()
-        || mapMarkerRequest.species() == null || mapMarkerRequest.species().isEmpty()) {
+        || mapMarkerRequest.petTypes() == null || mapMarkerRequest.petTypes().isEmpty()) {
       return MapMarkerResponse.empty();
     }
 
@@ -80,11 +80,11 @@ public class MapServiceImpl implements MapService {
           root.get("coordinates").get("longitude"), mapMarkerRequest.minLng(),
           mapMarkerRequest.maxLng());
       Predicate stateIn = root.get("state").in(mapMarkerRequest.states());
-      Predicate speciesIn = root.get("petType").in(mapMarkerRequest.species());
+      Predicate petTypesIn = root.get("petType").in(mapMarkerRequest.petTypes());
       Predicate notEndPost = criteriaBuilder.notEqual(
           root.get("state"), PostState.END);
 
-      return criteriaBuilder.and(latBetween, lngBetween, stateIn, speciesIn, notEndPost);
+      return criteriaBuilder.and(latBetween, lngBetween, stateIn, petTypesIn, notEndPost);
     });
 
     List<MarkerItem> markerItemList = postRepository.findAll(spec).stream()


### PR DESCRIPTION
## 📌 이슈 번호

\#47

## 💬 리뷰 포인트

* `species` → `petTypes` 파라미터명 변경 반영
* 요청 DTO(`MapPostRequest`, `MapMarkerRequest`) 필드명 업데이트 확인
* 서비스 레이어(`MapServiceImpl`) 내부 변수명(`petTypesIn`) 및 필터 로직 변경

## 🚀 상세 설명

* `MarkerItem` 레코드 필드 `species`를 `petType`으로 이름 변경
* `MapPostRequest` 및 `MapMarkerRequest`에서 `species` 파라미터명을 `petTypes`로 변경
* `MapServiceImpl` 내 `spec` 구성 시 종 필터 변수명도 `petTypesIn`으로 변경하여 올바른 파라미터 매핑 적용
* 위 수정에 따라 프론트엔드 요청 파라미터명 역시 `petTypes`로 업데이트 필요

## 📸 스크린샷

## 📢 노트