### PR TITLE
[Fix #54] Adopt 이미지 저장 누락 버그 수정 및 응답 로깅 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/entity/Adopt.java
@@ -71,5 +71,6 @@ public class Adopt extends PostCommon {
         this.endDate = adopt.getEndDate();
         this.shelterName = adopt.getShelterName();
         this.shelterPhone = adopt.getShelterPhone();
+        this.updateImage(adopt.getImages());
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/dto/response/AdoptItem.java
@@ -23,135 +23,141 @@ import lombok.Builder;
  */
 @Builder
 public record AdoptItem(
-	@NotBlank
-	String desertionNo,   // 구조번호
+    @NotBlank
+    String desertionNo,   // 구조번호
 
-	String rfidCd, // 동물등록번호(RFID 코드, 예: 123456789012345)
+    String rfidCd, // 동물등록번호(RFID 코드, 예: 123456789012345)
 
-	@NotBlank
-	String age,           // 나이 (예: 2025(60일미만)(년생))
-	@NotBlank
-	String colorCd,       // 색상
-	@NotBlank
-	String sexCd,         // 성별 (M: 수컷, F: 암컷, Q: 미상)
-	@NotBlank
-	String neuterYn,      // 중성화 여부 (Y: 예, N: 아니오, U: 미상)
-	@NotBlank
-	String weight,        // 체중 (예: 0.11(Kg))
-	@NotBlank
-	String noticeSdt,     // 공고시작일(YYYYMMDD)
-	@NotBlank
-	String noticeEdt,     // 공고종료일(YYYYMMDD)
-	@NotBlank
-	String careNm,        // 보호소이름
-	@NotBlank
-	String careTel,       // 보호소전화번호
-	@NotBlank
-	String careRegNo,     // 보호소번호
-	@NotBlank
-	String happenDt,      // 접수일(YYYYMMDD)
-	@NotBlank
-	String happenPlace,   // 발견장소
-	@NotNull
-	String upKindNm,      // 축종명 (예: 고양이)
-	@NotBlank
-	String specialMark,   // 특징
-	String popfile1,      // 이미지1 URL
-	String popfile2,      // 이미지2 URL
-	String popfile3,      // 이미지3 URL
-	String popfile4,      // 이미지4 URL
-	String popfile5,      // 이미지5 URL
-	String popfile6,      // 이미지6 URL
-	String popfile7,      // 이미지7 URL
-	String popfile8,      // 이미지8 URL
-	//        String upKindCd,      // 축종코드 (개: 417000, 고양이: 422400, 기타: 429900)
-	//        String kindFullNm,    // 품종 ([축종] 품종명)
-	//        String kindCd,        // 품종코드
-	//        String kindNm,        // 품종명 (예: 한국 고양이)
-	//        String noticeNo,      // 공고번호
-	//        String processState,  // 상태 (예: 보호중)
-	//        String careOwnerNm,   // 보호소대표자
-	String careAddr,      // 보호장소
-	String orgNm         // 관할기관
-	//        String updTm          // 수정일(yyyy-mm-dd hh:mm:ss)
+    @NotBlank
+    String age,           // 나이 (예: 2025(60일미만)(년생))
+    @NotBlank
+    String colorCd,       // 색상
+    @NotBlank
+    String sexCd,         // 성별 (M: 수컷, F: 암컷, Q: 미상)
+    @NotBlank
+    String neuterYn,      // 중성화 여부 (Y: 예, N: 아니오, U: 미상)
+    @NotBlank
+    String weight,        // 체중 (예: 0.11(Kg))
+    @NotBlank
+    String noticeSdt,     // 공고시작일(YYYYMMDD)
+    @NotBlank
+    String noticeEdt,     // 공고종료일(YYYYMMDD)
+    @NotBlank
+    String careNm,        // 보호소이름
+    @NotBlank
+    String careTel,       // 보호소전화번호
+    @NotBlank
+    String careRegNo,     // 보호소번호
+    @NotBlank
+    String happenDt,      // 접수일(YYYYMMDD)
+    @NotBlank
+    String happenPlace,   // 발견장소
+    @NotNull
+    String upKindNm,      // 축종명 (예: 고양이)
+    @NotBlank
+    String specialMark,   // 특징
+    String popfile1,      // 이미지1 URL
+    String popfile2,      // 이미지2 URL
+    String popfile3,      // 이미지3 URL
+    String popfile4,      // 이미지4 URL
+    String popfile5,      // 이미지5 URL
+    String popfile6,      // 이미지6 URL
+    String popfile7,      // 이미지7 URL
+    String popfile8,      // 이미지8 URL
+    //        String upKindCd,      // 축종코드 (개: 417000, 고양이: 422400, 기타: 429900)
+    //        String kindFullNm,    // 품종 ([축종] 품종명)
+    //        String kindCd,        // 품종코드
+    //        String kindNm,        // 품종명 (예: 한국 고양이)
+    //        String noticeNo,      // 공고번호
+    //        String processState,  // 상태 (예: 보호중)
+    //        String careOwnerNm,   // 보호소대표자
+    String careAddr,      // 보호장소
+    String orgNm         // 관할기관
+    //        String updTm          // 수정일(yyyy-mm-dd hh:mm:ss)
 ) {
-	private static LocalDateTime parseToLocalDateTime(String dateStr) {
-		return LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
-	}
 
-	private static PetType parsePetType(String upKindNm) {
-		return switch (upKindNm) {
-			case "개" -> PetType.DOG;
-			case "고양이" -> PetType.CAT;
-			case "기타" -> PetType.ETC;
-			default -> throw new IllegalArgumentException("알 수 없는 축종명: " + upKindNm);
-		};
-	}
+  private static LocalDateTime parseToLocalDateTime(String dateStr) {
+    return LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("yyyyMMdd")).atStartOfDay();
+  }
 
-	public Adopt toAdopt(Coordinates coordinates) {
-		Adopt adopt = Adopt.builder()
-			.desertionNum(desertionNo)
-			.petNum(rfidCd)
-			.age(age)
-			.color(colorCd)
-			.gender(sexCd)
-			.neuter(NeuterStatus.fromApiValue(neuterYn))
-			.weight(weight != null ? Float.parseFloat(weight.replace("(Kg)", "").trim()) : null)
-			.startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
-			.endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
-			.shelterName(careNm)
-			.shelterPhone(careTel)
-			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
-			.address(happenPlace)
-			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
-			.petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
-			.content(specialMark)
-			.state(parseToLocalDateTime(noticeEdt).isAfter(LocalDateTime.now())
-				? PostState.NOTICE : PostState.ADOPT) // 상태 정보는 API 응답에 포함되지 않음
-			.build();
+  private static PetType parsePetType(String upKindNm) {
+    return switch (upKindNm) {
+      case "개" -> PetType.DOG;
+      case "고양이" -> PetType.CAT;
+      case "기타" -> PetType.ETC;
+      default -> throw new IllegalArgumentException("알 수 없는 축종명: " + upKindNm);
+    };
+  }
 
-		getImageUrls().stream()
-			.map(Image::of)
-			.forEach(image -> image.setCommon(adopt)); // Adopt와 연결
+  public Adopt toAdopt(Coordinates coordinates) {
+    Adopt adopt = Adopt.builder()
+        .desertionNum(desertionNo)
+        .petNum(rfidCd)
+        .age(age)
+        .color(colorCd)
+        .gender(sexCd)
+        .neuter(NeuterStatus.fromApiValue(neuterYn))
+        .weight(
+            weight != null ? Float.parseFloat(weight.replace("(Kg)", "").replace(",", ".").trim())
+                : null)
+        .startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
+        .endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
+        .shelterName(careNm)
+        .shelterPhone(careTel)
+        .date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
+        .address(happenPlace)
+        .coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
+        .petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
+        .content(specialMark)
+        .state(parseToLocalDateTime(noticeEdt).isAfter(LocalDateTime.now())
+            ? PostState.NOTICE : PostState.ADOPT) // 상태 정보는 API 응답에 포함되지 않음
+        .build();
 
-		return adopt;
-	}
+    getImageUrls().stream()
+        .map(Image::of)
+        .forEach(adopt::addImage); // Adopt와 연결
 
-	public Adopt toAdopt(PostState postState, Coordinates coordinates) {
-		Adopt adopt = Adopt.builder()
-			.desertionNum(desertionNo)
-			.petNum(rfidCd)
-			.age(age)
-			.color(colorCd)
-			.gender(sexCd)
-			.neuter(NeuterStatus.fromApiValue(neuterYn))
-			.weight(weight != null ? Float.parseFloat(weight.replace("(Kg)", "").replace(",", ".").trim()) : null)
-			.startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
-			.endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
-			.shelterName(careNm)
-			.shelterPhone(careTel)
-			.date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
-			.address(happenPlace)
-			.coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
-			.petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
-			.content(specialMark)
-			.state(postState) // 상태 정보는 API 응답에 포함되지 않음
-			.build();
+    return adopt;
+  }
 
-		getImageUrls().stream()
-			.map(Image::of)
-			.forEach(image -> image.setCommon(adopt)); // Adopt와 연결
+  public Adopt toAdopt(PostState postState, Coordinates coordinates) {
 
-		return adopt;
-	}
+    Adopt adopt = Adopt.builder()
+        .desertionNum(desertionNo)
+        .petNum(rfidCd)
+        .age(age)
+        .color(colorCd)
+        .gender(sexCd)
+        .neuter(NeuterStatus.fromApiValue(neuterYn))
+        .weight(
+            weight != null ? Float.parseFloat(weight.replace("(Kg)", "").replace(",", ".").trim())
+                : null)
+        .startDate(noticeSdt != null ? parseToLocalDateTime(noticeSdt) : null)
+        .endDate(noticeEdt != null ? parseToLocalDateTime(noticeEdt) : null)
+        .shelterName(careNm)
+        .shelterPhone(careTel)
+        .date(happenDt != null ? parseToLocalDateTime(happenDt) : null)
+        .address(happenPlace)
+        .coordinates(coordinates) // 좌표 정보는 API 응답에 포함되지 않음
+        .petType(parsePetType(upKindNm)) // 축종명은 PetType으로 변환 필요
+        .content(specialMark)
+        .state(postState) // 상태 정보는 API 응답에 포함되지 않음
+        .build();
 
-	public List<String> getImageUrls() {
-		return Stream.of(popfile1, popfile2, popfile3, popfile4,
-				popfile5, popfile6, popfile7, popfile8)
-			.filter(Objects::nonNull)       // null 제거
-			.map(String::trim)              // 앞뒤 공백 제거
-			.filter(s -> !s.isEmpty())      // 빈 문자열 제거
-			.toList();                      // Java 16+: toList(), 그 이전 버전은 collect(Collectors.toList())
-	}
+    // 각 이미지에 Adopt 객체를 설정하여 양방향 연관관계 유지
+    getImageUrls().stream()
+        .map(Image::of)
+        .forEach(adopt::addImage); // Adopt와 연결
+
+    return adopt;
+  }
+
+  public List<String> getImageUrls() {
+    return Stream.of(popfile1, popfile2, popfile3, popfile4, popfile5, popfile6, popfile7, popfile8)
+        .filter(Objects::nonNull)       // null 제거
+        .map(String::trim)              // 앞뒤 공백 제거
+        .filter(s -> !s.isEmpty())      // 빈 문자열 제거
+        .toList();                      // Java 16+: toList(), 그 이전 버전은 collect(Collectors.toList())
+  }
 
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/publicdata/service/AdoptSyncServiceImpl.java
@@ -43,9 +43,9 @@ public class AdoptSyncServiceImpl implements AdoptSyncService {
 	@Override
 	public Mono<Void> addNewAdopts() {
 		return fetchAdoptItems(NEW_FETCH_SIZE)
-			.flatMapSequential(this::convertToAdoptWithCoordinates)
-			.collectList()
-			.flatMap(this::saveAdopts);
+        .flatMapSequential(this::convertToAdoptWithCoordinates)
+        .collectList()
+        .flatMap(this::saveAdopts);
 	}
 
 	@Override
@@ -107,7 +107,16 @@ public class AdoptSyncServiceImpl implements AdoptSyncService {
 				return Flux.empty();
 			}
 			List<AdoptItem> items = body.items().item();
-			return items.isEmpty() ? Flux.empty() : Flux.fromIterable(items);
+			return Flux.fromIterable(items)
+					.doOnNext(item -> {
+						if (item.getImageUrls().isEmpty()) {
+							log.warn("이미지 URL 누락! desertionNo={} popfile1={}, popfile2={}, popfile3={}, popfile4={}, popfile5={}, popfile6={}, popfile7={}, popfile8={}",
+									item.desertionNo(),
+									item.popfile1(), item.popfile2(), item.popfile3(), item.popfile4(),
+									item.popfile5(), item.popfile6(), item.popfile7(), item.popfile8()
+							);
+						}
+					});
 		} catch (Exception e) {
 			log.warn("입양 동물 데이터 추출 실패", e);
 			return Flux.empty();


### PR DESCRIPTION
## 📌 이슈 번호

> \#54

## 💬 리뷰 포인트

* 공공 API로부터 받은 입양 동물 데이터의 이미지 URL 필드(`popfile1`\~`popfile8`)가 존재함에도 불구하고, 해당 이미지가 DB에 저장되지 않던 문제를 해결했습니다.
* 이를 위해 `AdoptItem.toAdopt()` 메서드에서 이미지 객체를 Adopt 엔티티에 추가할 때 기존의 `image.setCommon(adopt)`만 호출하던 방식에서 `adopt.addImage(image)`를 사용하도록 수정하여, 연관관계가 올바르게 맺히도록 했습니다.
* 또한 외부 API 응답에서 이미지 URL 필드(`popfile1`\~`popfile8`)가 모두 빈 경우를 감지하여, 해당 상황을 추적할 수 있도록 경고 로그를 남기도록 처리했습니다.

## 🚀 상세 설명

* `PostCommon`의 `addImage()` 메서드를 사용하여 이미지 리스트의 각 요소가 `Adopt` 엔티티의 `images` 리스트에 명시적으로 추가되도록 처리했습니다.
* 기존 `AdoptItem.toAdopt()` 구현에서는 `getImageUrls().stream().map(Image::of).forEach(image -> image.setCommon(adopt));`로 이미지 객체의 `setCommon(adopt)`만 호출하여 단방향 연관관계만 설정하고 있었습니다. 이번 수정으로 `addImage(image)`를 호출해 양방향 연관관계가 완전하게 반영되도록 개선했습니다.
* 외부 API 응답에서 이미지 URL 필드(`popfile1`\~`popfile8`)가 모두 비어 있는 경우를 감지하여, 로그에 경고 메시지를 남기도록 추가했습니다. 이를 통해 이미지가 누락된 응답이 있을 때 원인을 추적할 수 있도록 했습니다.

## 📸 스크린샷

## 📢 노트

* 버그 재발을 방지하기 위해 `Adopt.updateWith()` 메서드에서도 `updateImage()`를 호출해 이미지 정보를 동기화하도록 수정했습니다. 기존 `updateWith()`에서는 이미지 관련 동기화가 누락되어 있었으므로, `updateWith()` 내에서 `updateImage()`를 호출하여 기존 이미지 리스트를 갱신하도록 개선했습니다.
