### PR TITLE
[Fix #57] 내가 작성한 게시글 가져오기 API 오류 해결

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -170,6 +170,7 @@ public class PostService {
     return newAdopts.size();
   }
 
+  @Transactional(readOnly = true)
   public Page<PostSummaryResponse> getMyPosts(User user, Pageable pageable) {
     return postRepository.findAllByUser(user, pageable).map(PostSummaryResponse::of);
   }


### PR DESCRIPTION
## 📌 이슈 번호
\#57 

## 💬 리뷰 포인트
- `getMyPosts` 메서드에 `@Transactional(readOnly = true)` 어노테이션이 올바르게 적용되었는지  
- 트랜잭션 적용 후 `LazyInitializationException` 문제가 해결되었는지

## 🚀 상세 설명
- 서비스 레이어 `PostService#getMyPosts`에 읽기 전용 트랜잭션을 걸어, 세션이 메서드 종료 시까지 유지되도록 했습니다.  
- 이로써 지연 로딩(`FetchType.LAZY`)된 `images` 컬렉션을 DTO 변환 시점에 안전하게 초기화할 수 있습니다.

## 📸 스크린샷

## 📢 노트 
