### PR TITLE
Fix MapService NPE on posts without images

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -88,7 +88,12 @@ public class MapServiceImpl implements MapService {
     });
 
     List<MarkerItem> markerItemList = postRepository.findAll(spec).stream()
-        .map(postCommon -> MarkerItem.of(postCommon, postCommon.getImages().get(0).getFileURL()))
+        .map(postCommon -> {
+          String url = postCommon.getImages().isEmpty()
+              ? null
+              : postCommon.getImages().get(0).getFileURL();
+          return MarkerItem.of(postCommon, url);
+        })
         .toList();
 
     return MapMarkerResponse.from(markerItemList);


### PR DESCRIPTION
## Summary
- avoid `IndexOutOfBoundsException` when building marker list

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b1b5397d8832abffe913563e0aac5