### PR TITLE
[FEAT #69] 채팅방 생성 API 구현

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatRoomController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.duckdns.petfinderapp.domain.chat.dto.ChatMessageDto;
 import org.duckdns.petfinderapp.domain.chat.dto.ChatRoomDto;
 import org.duckdns.petfinderapp.domain.chat.dto.ChatRoomPostDto;
+import org.duckdns.petfinderapp.domain.chat.dto.request.ChatRoomCreateResponse;
+import org.duckdns.petfinderapp.domain.chat.dto.resposne.ChatRoomCreateRequest;
 import org.duckdns.petfinderapp.domain.chat.service.ChatMessageService;
 import org.duckdns.petfinderapp.domain.chat.service.ChatRoomService;
 import org.duckdns.petfinderapp.domain.user.entity.User;
@@ -15,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -56,5 +60,15 @@ public class ChatRoomController {
         ChatRoomPostDto chatRoomPost = chatRoomService.getChatRoomPost(roomId, user.getId());
 
         return ApiResponse.onSuccess(HttpStatus.OK, "채팅방 상세 조회 성공", chatRoomPost);
+    }
+
+    @PostMapping("")
+    public ApiResponse<ChatRoomCreateResponse> createChatRoom(
+            @AuthenticationPrincipal User user,
+            @RequestBody ChatRoomCreateRequest chatRoomCreateRequest
+    ) {
+
+        ChatRoomCreateResponse chatRoom = chatRoomService.createChatRoom(user, chatRoomCreateRequest);
+        return ApiResponse.onSuccess(HttpStatus.CREATED, "채팅방 생성 성공", chatRoom);
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/request/ChatRoomCreateResponse.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/request/ChatRoomCreateResponse.java
@@ -1,0 +1,16 @@
+package org.duckdns.petfinderapp.domain.chat.dto.request;
+
+import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomCreateResponse(
+	Long roomId
+) {
+	public static ChatRoomCreateResponse of(ChatRoom chatRoom) {
+		return ChatRoomCreateResponse.builder()
+			.roomId(chatRoom.getId())
+			.build();
+	}
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/resposne/ChatRoomCreateRequest.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/dto/resposne/ChatRoomCreateRequest.java
@@ -1,0 +1,6 @@
+package org.duckdns.petfinderapp.domain.chat.dto.resposne;
+
+public record ChatRoomCreateRequest(
+	Long postId
+) {
+}

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/entity/ChatRoom.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -22,8 +23,8 @@ public class ChatRoom {
 
     @Column(name = "create_at",
             nullable = false,
-            updatable = false,
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+            updatable = false)
+    @CreationTimestamp
     private LocalDateTime createAt;
 
     /** 연관된 게시글 */
@@ -41,11 +42,15 @@ public class ChatRoom {
     @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_id", nullable = false)
-    private ChatRoom chatRoom;
-
     @Builder.Default
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessage> messages = new ArrayList<>();
+
+    public static ChatRoom of(PostCommon post, User sender, User receiver) {
+        return ChatRoom.builder()
+            .post(post)
+            .sender(sender)
+            .receiver(receiver)
+            .build();
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomConflictException.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/exception/ChatRoomConflictException.java
@@ -1,0 +1,23 @@
+package org.duckdns.petfinderapp.domain.chat.exception;
+
+import org.duckdns.petfinderapp.global.error.exception.ConflictException;
+
+public class ChatRoomConflictException extends ConflictException {
+	protected ChatRoomConflictException(String message) {
+		super(message);
+	}
+
+	public static ChatRoomConflictException ofInvalidPostState() {
+		return new ChatRoomConflictException("채팅방을 생성할 수 없는 게시글 입니다.");
+	}
+
+	public static ChatRoomConflictException ofCreatorSameAsPostAuthor() {
+		return new ChatRoomConflictException("채팅방 생성자와 게시글 작성자가 동일합니다.");
+	}
+
+	public static ChatRoomConflictException ofChatRoomAlreadyExists() {
+		return new ChatRoomConflictException("이미 존재하는 채팅방입니다.");
+	}
+}
+
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatRoomRepository.java
@@ -1,12 +1,12 @@
 package org.duckdns.petfinderapp.domain.chat.repository;
 
-import org.duckdns.petfinderapp.domain.chat.entity.ChatMessage;
 import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     // 특정 사용자가 참여한 채팅방 목록 조회 (최신 메시지 시간 순)
@@ -15,4 +15,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE (cr.sender.id = :userId OR cr.receiver.id = :userId) " +
             "ORDER BY cr.createAt DESC")
     List<ChatRoom> findChatRoomsByUserIdOrderByLatest(@Param("userId") Long userId);
+
+	Optional<Object> findChatRoomByPostId(Long postId);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatRoomService.java
@@ -3,11 +3,19 @@ package org.duckdns.petfinderapp.domain.chat.service;
 import lombok.RequiredArgsConstructor;
 import org.duckdns.petfinderapp.domain.chat.dto.ChatRoomDto;
 import org.duckdns.petfinderapp.domain.chat.dto.ChatRoomPostDto;
+import org.duckdns.petfinderapp.domain.chat.dto.request.ChatRoomCreateResponse;
+import org.duckdns.petfinderapp.domain.chat.dto.resposne.ChatRoomCreateRequest;
 import org.duckdns.petfinderapp.domain.chat.entity.ChatMessage;
 import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
+import org.duckdns.petfinderapp.domain.chat.exception.ChatRoomConflictException;
+import org.duckdns.petfinderapp.domain.chat.exception.ChatRoomNotFoundException;
 import org.duckdns.petfinderapp.domain.chat.repository.ChatRoomRepository;
 import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
+import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
+import org.duckdns.petfinderapp.domain.post.enums.PostState;
+import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
 import org.duckdns.petfinderapp.domain.user.entity.User;
+import org.duckdns.petfinderapp.domain.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,6 +27,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
+    private final PostRepository postRepository;
 
     public List<ChatRoomDto> getChatRoomList(Long userId) {
         // DB에서 해당 사용자가 참여한 채팅방들을 가져온다
@@ -77,5 +86,33 @@ public class ChatRoomService {
     private boolean isParticipant(ChatRoom chatRoom, Long userId) {
         return chatRoom.getSender().getId().equals(userId) ||
                 chatRoom.getReceiver().getId().equals(userId);
+    }
+
+    public ChatRoomCreateResponse createChatRoom(User user, ChatRoomCreateRequest chatRoomCreateRequest) {
+        Long postId = chatRoomCreateRequest.postId();
+        // 채팅방이 이미 존재하는지
+        chatRoomRepository.findChatRoomByPostId(postId).ifPresent(chatRoom -> {
+            throw ChatRoomConflictException.ofChatRoomAlreadyExists();
+        });
+        // 존재하는 게시글인지
+        PostCommon post = postRepository.findById(postId)
+                .orElseThrow(ChatRoomNotFoundException::missingChatRoom);
+        // 게시글 상태가 LOST 또는 SIGHT 인지
+        if (post.getState() != PostState.LOST && post.getState() != PostState.SIGHT) {
+            throw ChatRoomConflictException.ofInvalidPostState();
+        }
+        // 존재하는 사용자인지
+        if (user == null) {
+            throw UserNotFoundException.missingUser();
+        }
+        // 게시글 작성자와 채팅방 생성자가 동일한지
+        if (post.getUser().getId().equals(user.getId())) {
+            throw ChatRoomConflictException.ofCreatorSameAsPostAuthor();
+        }
+
+        // 채팅방 생성
+        ChatRoom chatRoom = ChatRoom.of(post, user, post.getUser());
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+        return ChatRoomCreateResponse.of(savedChatRoom);
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/global/error/exception/ConflictException.java
+++ b/src/main/java/org/duckdns/petfinderapp/global/error/exception/ConflictException.java
@@ -1,0 +1,10 @@
+package org.duckdns.petfinderapp.global.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends BaseException {
+
+	protected ConflictException(String message) {
+		super(HttpStatus.CONFLICT, message);
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호
\#69

## 💬 리뷰 포인트
- 채팅방 생성 시점 저장을 위한 `createAt` 필드 추가 및 `@CreationTimestamp` 적용
- 엔티티에 정적 팩토리 메서드 `ChatRoom.of(...)` 추가로 생성 로직 단순화
- 채팅방 생성용 Request/Response DTO (`ChatRoomCreateRequest`, `ChatRoomCreateResponse`) 구현
- 채팅방 생성 API 엔드포인트 및 서비스 로직 구현 (존재 검사, 상태 검사, 작성자 동일성 검사)
- 충돌 상황 전용 예외 `ChatRoomConflictException` 추가 및 전파

## 🚀 상세 설명
1. **채팅방 생성 날짜 관리**  
   `ChatRoom` 엔티티에 `createAt` 컬럼(`TIMESTAMP DEFAULT CURRENT_TIMESTAMP`)을 추가하고, Hibernate `@CreationTimestamp`를 사용해 자동으로 생성 일시를 기록합니다.

2. **정적 팩토리 메서드**  
   `ChatRoom.of(post, sender, receiver)` 메서드를 통해 생성자 호출을 캡슐화하여 가독성을 높였습니다.

3. **DTO 추가**  
   - Request: `ChatRoomCreateRequest(postId)`  
   - Response: `ChatRoomCreateResponse(roomId)`  
   빌더 패턴과 `record` 타입을 사용해 불변성을 보장합니다.

4. **컨트롤러 및 서비스 로직**  
   - `ChatRoomController#createChatRoom` 엔드포인트(`POST /api/chat/rooms`) 구현  
   - `ChatRoomService#createChatRoom`에서  
     - 이미 생성된 채팅방 중복 검사 (`findChatRoomByPostId`)  
     - 게시글 존재 및 상태 검사 (LOST, SIGHT)  
     - 사용자 존재 및 작성자 중복 검사  
     - 실제 채팅방 저장 후 생성된 ID를 반환  

5. **충돌 전용 예외 처리**  
   `ChatRoomConflictException` 추가 (`ofInvalidPostState`, `ofCreatorSameAsPostAuthor`, `ofChatRoomAlreadyExists`), 전역 예외 핸들러를 통해 HTTP 409 상태로 응답됩니다.

## 📸 스크린샷

## 📢 노트