### PR TITLE
♻️Refactor[#70] 게시글 상세보기에 채팅방 id 추가

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/repository/ChatRoomRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     // 특정 사용자가 참여한 채팅방 목록 조회 (최신 메시지 시간 순)
@@ -15,4 +16,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE (cr.sender.id = :userId OR cr.receiver.id = :userId) " +
             "ORDER BY cr.createAt DESC")
     List<ChatRoom> findChatRoomsByUserIdOrderByLatest(@Param("userId") Long userId);
+
+    // 게시글 ID에 대한 유저 ID 조회
+    @Query("SELECT cr FROM ChatRoom cr WHERE cr.post.id = :postId AND " +
+            "(cr.sender.id = :userId OR cr.receiver.id = :userId)")
+    Optional<ChatRoom> findByPostIdAndUserId(@Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/controller/CommonController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/controller/CommonController.java
@@ -28,8 +28,10 @@ public class CommonController {
 
     // Found 상세 조회
     @GetMapping("/posts/found/{id}")
-    public ResCommon getFound(@PathVariable Long id) {
-        return commonService.searchFound(id);
+    public ResCommon getFound(
+            @PathVariable Long id,
+            @AuthenticationPrincipal User user) {
+        return commonService.searchFound(id, user);
     }
 
     // found 게시글 수정

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/controller/LostController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/controller/LostController.java
@@ -28,8 +28,9 @@ public class LostController {
 
     // lost 상세 조회
     @GetMapping("/posts/lost/{id}")
-    public ResLost getLost(@PathVariable Long id) {
-        return lostService.searchLost(id);
+    public ResLost getLost(@PathVariable Long id,
+                           @AuthenticationPrincipal User user) {
+        return lostService.searchLost(id, user);
     }
 
     // lost 업데이트

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/ResCommon.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/ResCommon.java
@@ -2,6 +2,7 @@ package org.duckdns.petfinderapp.domain.post.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
 import org.duckdns.petfinderapp.domain.post.entity.PostCommon;
 import org.duckdns.petfinderapp.domain.post.enums.PetType;
 import org.duckdns.petfinderapp.domain.post.enums.PostState;
@@ -12,10 +13,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@Builder
+@Builder (toBuilder = true)
 public class ResCommon {
     private Long id;
     private Long userId;
+    private Long chatId;
     private String userName;
     private String userImg;
     private PostState state;
@@ -35,6 +37,7 @@ public class ResCommon {
                 .userId(post.getUser() != null ? post.getUser().getId() : null)
                 .userName(user != null ? user.getName() : null)
                 .userImg(user != null ? user.getImageUrl() : null)
+                .chatId(null)
                 .state(post.getState())
                 .createdAt(post.getCreateAt())
                 .date(post.getDate())
@@ -43,6 +46,12 @@ public class ResCommon {
                 .content(post.getContent())
                 .coordinates(new ResCoordinates(post.getCoordinates()))
                 .images(post.getImages().stream().map(ImageDto::new).collect(Collectors.toList()))
+                .build();
+    }
+
+    public static ResCommon of(PostCommon post, Long chatRoomId) {
+        return of(post).toBuilder()
+                .chatId(chatRoomId)
                 .build();
     }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/ResLost.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/response/ResLost.java
@@ -14,4 +14,10 @@ public class ResLost {
         this.common = ResCommon.of(lost);
         this.lost = new LostDto(lost);
     }
+
+    public ResLost(Lost lost, Long chatRoomId) {
+        this.id = lost.getId();
+        this.common = ResCommon.of(lost, chatRoomId);
+        this.lost = new LostDto(lost);
+    }
 }

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/LostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/LostService.java
@@ -1,7 +1,10 @@
 package org.duckdns.petfinderapp.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
+import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
+import org.duckdns.petfinderapp.domain.chat.repository.ChatRoomRepository;
 import org.duckdns.petfinderapp.domain.post.dto.request.*;
+import org.duckdns.petfinderapp.domain.post.dto.response.ResCommon;
 import org.duckdns.petfinderapp.domain.post.dto.response.ResLost;
 import org.duckdns.petfinderapp.domain.post.entity.Image;
 import org.duckdns.petfinderapp.domain.post.entity.Lost;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class LostService {
     private final LostRepository lostRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final S3Uploader s3Uploader;
 
     // 게시글 작성
@@ -74,10 +78,21 @@ public class LostService {
 
     // Lost 조회
     @Transactional(readOnly = true)
-    public ResLost searchLost(Long id) {
+    public ResLost searchLost(Long id, User user) {
         Lost lost = lostRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
-        return new ResLost(lost);
+
+        // 게시글 작성자인 경우 chatRoomId는 null
+        if (lost.getUser().getId().equals(user.getId())) {
+            return new ResLost(lost);
+        }
+
+        // 사용자가 참여 중인 채팅방 조회
+        Long chatRoomId = chatRoomRepository.findByPostIdAndUserId(id, user.getId())
+                .map(ChatRoom::getId)
+                .orElse(null);
+
+        return new ResLost(lost, chatRoomId);
     }
 
     // lost 게시글 수정

--- a/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/service/PostService.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.duckdns.petfinderapp.domain.chat.entity.ChatRoom;
+import org.duckdns.petfinderapp.domain.chat.repository.ChatRoomRepository;
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonCreate;
 import org.duckdns.petfinderapp.domain.post.dto.request.CommonUpdate;
 import org.duckdns.petfinderapp.domain.post.dto.response.PostSummaryResponse;
@@ -33,6 +35,7 @@ public class PostService {
 
   private final PostRepository postRepository;
   private final AdoptRepository adoptRepository;
+  private final ChatRoomRepository chatRoomRepository;
   private final S3Uploader s3Uploader;
 
   // 게시글 작성
@@ -67,13 +70,24 @@ public class PostService {
 
   // Found 조회
   @Transactional(readOnly = true)
-  public ResCommon searchFound(Long id) {
+  public ResCommon searchFound(Long id, User user) {
     PostCommon common = postRepository.findById(id)
         .orElseThrow(() -> new IllegalArgumentException("해당 게시물이 존재하지 않습니다."));
     if (!(common instanceof Found found)) {
       throw new IllegalArgumentException("해당 게시물은 FOUND 타입이 아닙니다.");
     }
-    return ResCommon.of(found);
+
+    // 게시글 작성자인 경우 chatRoomId는 null
+    if (found.getUser().getId().equals(user.getId())) {
+      return ResCommon.of(found);
+    }
+
+    // 사용자가 참여 중인 채팅방 조회
+    Long chatRoomId = chatRoomRepository.findByPostIdAndUserId(id, user.getId())
+            .map(ChatRoom::getId)
+            .orElse(null);
+
+    return ResCommon.of(found, chatRoomId);
   }
 
 


### PR DESCRIPTION
## 📌 이슈 번호
> #70 

## 💬 리뷰 포인트
> 게시글 상세보기에 채팅방 id 추가했습니다.

## 🚀 상세 설명
- 컨트롤러
Controller에서 게시글을 조회 → 경로에서 게시글 id 추출 + 사용자 정보 가져오기. Service로 Id와 사용자 정보 전달 
- 서비스
→ (이전 상세보기와 이하 동일), **채팅방 조회 (채팅방이 있을 경우 ID-sender,receiver- 반환, 없을 경우 null)**  → 채팅방 ID를 포함해 Dto 반환

... 이게 맞나..?