### PR TITLE
Fix/chatrooms #74

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatRoomService.java
@@ -17,6 +17,7 @@ import org.duckdns.petfinderapp.domain.post.repository.PostRepository;
 import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.duckdns.petfinderapp.domain.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final PostRepository postRepository;
 
+    @Transactional(readOnly = true)
     public List<ChatRoomDto> getChatRoomList(Long userId) {
         // DB에서 해당 사용자가 참여한 채팅방들을 가져온다
         List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByUserIdOrderByLatest(userId);

--- a/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/map/service/MapServiceImpl.java
@@ -88,9 +88,13 @@ public class MapServiceImpl implements MapService {
     });
 
     List<MarkerItem> markerItemList = postRepository.findAll(spec).stream()
-        .map(postCommon -> MarkerItem.of(postCommon, postCommon.getImages().get(0).getFileURL()))
+        .map(postCommon -> MarkerItem.of(postCommon, getFirstImageUrl(postCommon)))
         .toList();
 
     return MapMarkerResponse.from(markerItemList);
+  }
+
+  private String getFirstImageUrl(PostCommon postCommon) {
+    return postCommon.getImages().isEmpty() ? null : postCommon.getImages().get(0).getFileURL();
   }
 }


### PR DESCRIPTION
## 📌 이슈 번호

\#74

## 💬 리뷰 포인트

* ChatRoomService의 `getChatRoomList` 메서드에 `@Transactional(readOnly = true)` 적용 여부
* MapServiceImpl에서 직접 호출하던 `postCommon.getImages().get(0)` 로직을 `getFirstImageUrl` 헬퍼 메서드로 대체한 점
* 빈 이미지 리스트 접근 시 `IndexOutOfBoundsException`/`NullPointerException` 방지 로직

## 🚀 상세 설명

* **ChatRoomService.java**

  * 서비스 레이어의 `getChatRoomList` 메서드에 `@Transactional(readOnly = true)` 어노테이션을 추가하여, 지연 로딩된 연관 엔티티에 접근할 때 세션이 유지되도록 함으로써 `LazyInitializationException` 방지.
* **MapServiceImpl.java**

  * 기존 `.map(postCommon -> MarkerItem.of(postCommon, postCommon.getImages().get(0).getFileURL()))` 호출부를

    ```java
    .map(postCommon -> MarkerItem.of(postCommon, getFirstImageUrl(postCommon)))
    ```

    로 변경.
  * `getFirstImageUrl(PostCommon postCommon)` 헬퍼 메서드를 추가해, 이미지 리스트가 비어 있으면 `null`을 반환하고, 아닐 경우 첫 번째 이미지 URL을 반환하도록 구현. 이를 통해 빈 리스트 접근 시 발생하던 `IndexOutOfBoundsException` 및 NPE를 방지.

## 📸 스크린샷

변경된 로직은 UI 변경이 없으므로 스크린샷 없음

## 📢 노트
