### PR TITLE
[Fix #79] 읽기전용 트랜잭션 추가 및 유저 비교 로직 개선

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatMessageServiceImpl.java
@@ -13,6 +13,7 @@ import org.duckdns.petfinderapp.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,11 +22,13 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Page<ChatMessageDto> getChatRoomMessages(User user, Long roomId, Pageable pageable) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
             .orElseThrow(ChatRoomNotFoundException::missingChatRoom);
 
-        if (!chatRoom.getSender().equals(user) && !chatRoom.getReceiver().equals(user)) {
+        if (!chatRoom.getSender().getId().equals(user.getId()) &&
+            !chatRoom.getReceiver().getId().equals(user.getId())) {
             throw ChatRoomAccessDeniedException.accessDenied();
         }
 


### PR DESCRIPTION
## 📌 이슈 번호
\#79

## 💬 리뷰 포인트
- 읽기 전용 트랜잭션 적용
- 채팅방  참여자 비교 로직 개선

## 🚀 상세 설명
- ChatMessageServiceImpl getChatRoomMessages 메서드에 읽기전용 트랜잭션 적용
- 채팅방 참여자 비교 로직을 기존에는 유저 엔티티 객체 전체를 비교에서 유저 ID만 비교하는거로 변경

## 📸 스크린샷

## 📢 노트
