### PR TITLE
[Fix #79]: 이미지가 비어 있는 경우 처리

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/post/dto/PostInfoDto.java
@@ -23,7 +23,7 @@ public record PostInfoDto (
 			.date(post.getCreateAt())
 			.address(post.getAddress())
 			.description(post.getContent())
-			.imageUrl(post.getImages().get(0).getFileURL())
+			.imageUrl(post.getImages().isEmpty() ? null : post.getImages().get(0).getFileURL())
 			.build();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
\#79

## 💬 리뷰 포인트
- 이미지가 비어있는 경우 처리함
- PostInfoDto의 of 메서드 중 imageUrl을 설정하는 과정에서 이미지가 없는 경우 null을 할당하도록 설정

## 🚀 상세 설명
- 기존에는 이미지가 없는 경우를 고려하지 못하여 0번 인덱스에 접근할 때 NPE가 발생
- 이를 방지하고자 isEmpty()로 먼저 검사 후 비어있다면 null을 할당하고 비어있지 않다면 게시글의 첫번째 이미지를 할당하도록 설정

## 📸 스크린샷

## 📢 노트
