### PR TITLE
[Fix #85]: post null 처리

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/service/ChatServiceImpl.java
@@ -46,8 +46,14 @@ public class ChatServiceImpl implements ChatService {
 		}
 		String messageContent = message.message();
 
-		PostCommon sharePost = postRepository.findById(message.post().postId())
-				.orElseThrow(PostNotFoundException::missingPost);
+		PostCommon sharePost;
+		if (message.post() == null) {
+			// 일반 채팅 메시지 처리
+			sharePost = null;
+		} else {
+			sharePost = postRepository.findById(message.post().postId())
+					.orElseThrow(PostNotFoundException::missingPost);
+		}
 
 		chatMessageRepository.save(ChatMessage.of(chatRoom.get(), sender.get(), messageContent, sharePost));
 


### PR DESCRIPTION
## 📌 이슈 번호
\#85

## 💬 리뷰 포인트
- 메시지에 공유된 게시글 정보가 없다면, null 값이 저장되도록 수정

## 🚀 상세 설명
- ChatServiceImpl의 processMessage에서 공유된 채팅방을 저장하기 위해 ChatMessageDto에서 postId를 얻는 과정에서 NPE 발생
- ChatMessageDto에서 psotId를 얻기 전에 post가 있는지 확인 후 postId에 접근
- post가 있다면 postId와 다른 post 정보로 PostCommon 엔티티 생성하여 ChatMessage 엔티티의 sharePost에 할당하여 저장
- post가 없다면 null을 chatMessage 엔티티의 sharePost에 할당하여 저장

## 📸 스크린샷

## 📢 노트
