### PR TITLE
[Fix #62] Lazy 초기화 문제 해결

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityRepository.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityRepository.java
@@ -4,7 +4,17 @@ import java.util.List;
 
 import org.duckdns.petfinderapp.domain.similarity.entity.Similarity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SimilarityRepository extends JpaRepository<Similarity, Long> {
-	List<Similarity> findAllByLostPostId(Long postId);
+
+  @Query("""
+        SELECT s FROM Similarity s
+         JOIN FETCH s.similarPost sp
+         LEFT JOIN FETCH sp.images
+        WHERE s.lostPost.id = :postId
+      """)
+  List<Similarity> findAllWithImagesByLostPostId(@Param("postId") Long postId);
 }
+

--- a/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityService.java
@@ -124,17 +124,21 @@ public class SimilarityService {
     return similarityRepository.saveAll(similarityList);
   }
 
+  @Transactional(readOnly = true)
   public SseEmitter subscribeToSimilarity(User user, Long postId) {
     PostCommon post = postRepository.findById(postId)
         .orElseThrow(PostNotFoundException::missingPostCommon);
     if (!post.getUser().getId().equals(user.getId())) {
       throw SimilarityAccessDeniedException.accessDenied();
     }
+    if (post.getState() != PostState.LOST) {
+      throw SimilarityAccessDeniedException.accessDenied();
+    }
 
     SseEmitter emitter = notifier.register(postId);
 
     // 1) 기존 데이터 조회
-    List<SseSimilarityItem> existing = similarityRepository.findAllByLostPostId(postId)
+    List<SseSimilarityItem> existing = similarityRepository.findAllWithImagesByLostPostId(postId)
         .stream().map(SseSimilarityItem::of).toList();
 
     // 2) 이미 값이 있으면 즉시 전송


### PR DESCRIPTION
## 📌 이슈 번호
> \#62

## 💬 리뷰 포인트
-트랜잭션 및 페치 조인 적용

## 🚀 상세 설명
- Lazy 초기화를 막기 위해 트랜잭션 적용
- 트랜잭션 밖에서 지연 로딩 예외 없이 안전하게 이미지 조회할 수 있도록 페치 조인 적용

## 📸 스크린샷

## 📢 노트
