### PR TITLE
Fix: Update SimilarityNotifier to handle IOException and IllegalStateException

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityNotifier.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityNotifier.java
@@ -25,14 +25,13 @@ public class SimilarityNotifier {
 		SseEmitter emitter = new SseEmitter(30_000L); // 30초 타임아웃 설정
 		log.debug("SSE registered for postId: {}", postId);
 
-		ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(
-			() -> {
+		ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(() -> {
 				try {
 					emitter.send(SseEmitter.event()
 						.name("ping")
 						.data("keep-alive")
 					);
-				} catch (IOException e) {
+				} catch (IOException | IllegalStateException e) {
 					emitter.completeWithError(e);
 				}
 			}, Duration.ofSeconds(20) // 20초 주기로 ping 이벤트 전송
@@ -52,7 +51,7 @@ public class SimilarityNotifier {
 					.name("ping")
 					.data("keep-alive")
 			);
-		} catch (IOException e) {
+		} catch (IOException | IllegalStateException e) {
 			log.warn("Initial ping failed for postId: {}", postId, e);
 			cleanupTask.run();
 			return emitter;
@@ -80,7 +79,7 @@ public class SimilarityNotifier {
 					.data(response)
 				);
 				emitter.complete();
-			} catch (IOException e) {
+			} catch (IOException | IllegalStateException e) {
 				emitter.completeWithError(e);
 			}
 		}


### PR DESCRIPTION
## 📌 이슈 번호

\#62

## 💬 리뷰 포인트

 * `register()` 내부 ping 스케줄러에서 `IOException` 뿐만 아니라 `IllegalStateException`도 함께 캐치하도록 수정

## 🚀 상세 설명

 * SseEmitter를 이용한 ping 루프에서, 스트림이 이미 종료된 상태(`complete()`)에서 `send()` 호출 시 발생하던 `IllegalStateException`을 잡지 못해 스케줄이 남아있던 문제 해결
 * `scheduleAtFixedRate` 람다 블록의 `catch` 절을 `catch (IOException | IllegalStateException e)` 로 확장하여 두 가지 예외 모두 처리

## 📸 스크린샷

 해당 없음

## 📢 노트