### PR TITLE
Feat/similarity #62

### DIFF
--- a/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/chat/controller/ChatMessageController.java
@@ -6,7 +6,6 @@ import org.duckdns.petfinderapp.domain.chat.service.ChatService;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class ChatMessageController {
 	private final ChatService chatService;
 
-	@Transactional
 	@MessageMapping("/chatrooms/{roomId}")
 	public void handleChatMessage(
 		@DestinationVariable Long roomId,
@@ -26,7 +24,6 @@ public class ChatMessageController {
 		chatService.processMessage(roomId, messageDto);
 	}
 
-	@Transactional
 	@MessageMapping("/chatrooms/{roomId}/read")
 	public void handleReadMessage(
 			@DestinationVariable Long roomId,

--- a/src/main/java/org/duckdns/petfinderapp/domain/push/service/FcmService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/push/service/FcmService.java
@@ -78,6 +78,7 @@ public class FcmService {
                     .redirect(dto.getRedirect())
                     .build();
             pushRepository.save(push);
+            log.info("푸시 알림 저장 성공: {}", push);
 
         } catch (FirebaseMessagingException e) {
             e.printStackTrace();

--- a/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityService.java
+++ b/src/main/java/org/duckdns/petfinderapp/domain/similarity/service/SimilarityService.java
@@ -71,33 +71,41 @@ public class SimilarityService {
   }
 
   private void processOtherSimilarity(Long postId, PostState postState) {
-    PostCommon postCommon = postRepository.findById(postId)
+    PostCommon otherPost = postRepository.findById(postId)
         .orElseThrow(PostNotFoundException::missingPostCommon);
 
     SimilarityRequest similarityRequest = SimilarityRequest.of(postId, postState,
-        getImageUrl(postCommon));
+        getImageUrl(otherPost));
     ImageAiSimilarityResponse response = imageAiClient.fetchSimilarLostPosts(similarityRequest);
     log.info("유사 실종 게시글 조회 완료: postId={}, response={}", postId, response);
 
     saveSimilarResponse(postState, response);
 
-    response.postIdList().forEach(this::sendSimilarPostPushNotification);
+    response.postIdList().forEach(lostPostId -> {
+      try {
+        this.sendSimilarPostPushNotification(otherPost, lostPostId);
+      } catch (PostNotFoundException e) {
+        log.warn("존재하지 않는 게시글, 알림 스킵: {}", lostPostId);
+      } catch (Exception e) {
+        log.error("알림 전송 중 오류 발생, 계속 진행: lostPostId={}, {}", lostPostId, e.getMessage());
+      }
+    });
   }
 
-  private void sendSimilarPostPushNotification(Long postId) {
-    PostCommon post = postRepository.findById(postId)
+  private void sendSimilarPostPushNotification(PostCommon otherPost, Long lostPostId) {
+    PostCommon lostPost = postRepository.findById(lostPostId)
         .orElseThrow(PostNotFoundException::missingPostCommon);
 
 		fcmService.sendMessage(
-        post.getUser(),
+        lostPost.getUser(),
         FcmResponseDto.of(
             null,
             "새로운 게시글",
-            "등록된 게시글과 유사한 " + post.getState().toKoreanString() + "글이 올라왔어요",
-            post.getFirstImageUrl()+","+post.getId().toString()
+            "등록된 게시글과 유사한 " + otherPost.getState().toKoreanString() + "글이 올라왔어요",
+            lostPost.getFirstImageUrl()+","+lostPost.getId().toString()
 				)
     );
-		log.info("유사 게시글 푸시 알림 전송: postId={}, user={}", postId, post.getUser().getId());
+		log.info("유사 게시글 푸시 알림 전송: postId={}, user={}", otherPost.getId(), lostPost.getUser().getId());
   }
 
   private List<Similarity> saveSimilarResponse(PostState postState,


### PR DESCRIPTION
## 📌 이슈 번호

\#62

## 💬 리뷰 포인트

* 없는 게시글 ID 예외 처리로 전체 트랜잭션 롤백 방지
* `sendSimilarPostPushNotification` 파라미터 및 메시지 상태 참조 수정
* FCM 저장 직후 성공 로그 추가로 DB 저장 여부 가시성 향상

## 🚀 상세 설명

* `SimilarityService.processOtherSimilarity`의 `forEach` 내부를 `try/catch`로 감싸서

  * `PostNotFoundException` 발생 시 WARN 로그만 남기고 다음 ID로 계속 처리
  * 기타 예외도 ERROR 레벨로 로깅해 한 건 실패가 전체 처리를 중단하지 않도록 함
* `sendSimilarPostPushNotification` 시그니처를 `(PostCommon otherPost, Long lostPostId)`로 변경하고
  메시지 본문에서 잘못 참조되던 `post.getState()`를 `otherPost.getState()`로 교정
* `FcmService.sendMessage`에서 `pushRepository.save(push)` 직후 `log.info("푸시 알림 저장 성공: {}", push)` 추가

## 📸 스크린샷

없음

## 📢 노트

* 기존 기능 호환성을 유지하면서 데이터 누락 문제를 우선 해결
* 이후 FCM 전송 실패에 대한 트랜잭션 분리 검토 예정
